### PR TITLE
Get dependabot to update the Dockerfile base image

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,15 +1,20 @@
 version: 2
 updates:
-- package-ecosystem: bundler
-  directory: "/"
-  allow:
-    - dependency-type: "all"
-  schedule:
-    interval: daily
-    time: "03:00"
-    timezone: Europe/London
-  open-pull-requests-limit: 10
-  ignore:
-  - dependency-name: sentry-raven
-    versions:
-    - 3.1.2
+  - package-ecosystem: bundler
+    directory: "/"
+    allow:
+      - dependency-type: "all"
+    schedule:
+      interval: daily
+      time: "03:00"
+      timezone: Europe/London
+    open-pull-requests-limit: 10
+    ignore:
+      - dependency-name: sentry-raven
+        versions:
+          - 3.1.2
+
+  - package-ecosystem: "docker"
+    directory: "/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
## What

Adds docker config, following this example: https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuring-dependabot-version-updates#example-dependabotyml-file

Indenting the list should make no functional difference, but is what my editor seems to prefer for YAML, and I see it more often indented :shrug:

No story

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
