### PR TITLE
Lep 91 remove unused assessment errors table

### DIFF
--- a/app/models/assessment.rb
+++ b/app/models/assessment.rb
@@ -23,7 +23,6 @@ class Assessment < ApplicationRecord
   has_many :properties, through: :capital_summary, dependent: :destroy
   has_many :vehicles, through: :capital_summary, dependent: :destroy
   has_many :capital_items, through: :capital_summary, dependent: :destroy
-  has_many :assessment_errors, dependent: :destroy
   has_many :explicit_remarks, dependent: :destroy
   has_many :employments, dependent: :destroy, class_name: "ApplicantEmployment"
   has_many :partner_employments, dependent: :destroy

--- a/app/services/calculators/housing_costs_calculator.rb
+++ b/app/services/calculators/housing_costs_calculator.rb
@@ -28,7 +28,6 @@ module Calculators
     def monthly_housing_benefit
       @monthly_housing_benefit ||= begin
         housing_benefit_payments = Calculators::MonthlyEquivalentCalculator.call(
-          assessment_errors: @disposable_income_summary.assessment.assessment_errors,
           collection: housing_benefit_records,
         )
         housing_benefit_payments + monthly_housing_benefit_regular_transactions
@@ -37,7 +36,6 @@ module Calculators
 
     def gross_housing_costs_bank
       Calculators::MonthlyEquivalentCalculator.call(
-        assessment_errors: @disposable_income_summary.assessment.assessment_errors,
         collection: @disposable_income_summary.housing_cost_outgoings,
         amount_method: :allowable_amount,
       )
@@ -66,7 +64,6 @@ module Calculators
 
     def calculate_actual_housing_costs
       Calculators::MonthlyEquivalentCalculator.call(
-        assessment_errors: @disposable_income_summary.assessment.assessment_errors,
         collection: housing_cost_outgoings,
       )
     end

--- a/app/services/calculators/monthly_equivalent_calculator.rb
+++ b/app/services/calculators/monthly_equivalent_calculator.rb
@@ -2,8 +2,8 @@
 
 module Calculators
   class MonthlyEquivalentCalculator
-    def self.call(assessment_errors:, collection:, date_method: :payment_date, amount_method: :amount)
-      new.call(assessment_errors:, collection:, date_method:, amount_method:)
+    def self.call(collection:, date_method: :payment_date, amount_method: :amount)
+      new.call(collection:, date_method:, amount_method:)
     end
 
     # examines all records in a given collection, to work out the equivalent value per calendar month
@@ -12,14 +12,12 @@ module Calculators
     # * date_method: The method to call on each record in the collection to retrieve the payment date
     # * amount_method: The method to call on each record in the collection to retrieve the payment amount
     #
-    def call(assessment_errors:, collection:, date_method: :payment_date, amount_method: :amount)
+    def call(collection:, date_method: :payment_date, amount_method: :amount)
       return 0.0 if collection.empty?
 
       @monthly_equivalent_calculator_collection = collection
       @monthly_equivalent_calculator_date_method = date_method
       @monthly_equivalent_calculator_amount_method = amount_method
-
-      assessment_errors.create!(record_id: id, record_type: self.class, error_message: converter.error_message) if converter.error?
       converter.monthly_amount
     end
 

--- a/app/services/calculators/monthly_income_converter.rb
+++ b/app/services/calculators/monthly_income_converter.rb
@@ -1,6 +1,6 @@
 module Calculators
   class MonthlyIncomeConverter
-    attr_reader :monthly_amount, :error_message
+    # attr_reader :error_message
 
     def initialize(frequency, payments)
       @frequency = frequency
@@ -10,15 +10,10 @@ module Calculators
       @monthly_amount = nil
     end
 
-    def run
+    def monthly_amount
       raise "Unrecognized frequency" unless @frequency.in?(CFEConstants::VALID_FREQUENCIES)
 
-      @monthly_amount = __send__("process_#{@frequency}")
-    end
-
-    def error?
-      run
-      @error
+      __send__("process_#{@frequency}")
     end
 
   private

--- a/app/services/calculators/monthly_income_converter.rb
+++ b/app/services/calculators/monthly_income_converter.rb
@@ -1,7 +1,5 @@
 module Calculators
   class MonthlyIncomeConverter
-    # attr_reader :error_message
-
     def initialize(frequency, payments)
       @frequency = frequency
       @payments = payments

--- a/app/services/calculators/state_benefits_calculator.rb
+++ b/app/services/calculators/state_benefits_calculator.rb
@@ -12,7 +12,6 @@ module Calculators
 
         state_benefits.each do |state_benefit|
           monthly_value = Calculators::MonthlyEquivalentCalculator.call(
-            assessment_errors: state_benefit.gross_income_summary.assessment.assessment_errors,
             collection: state_benefit.state_benefit_payments,
           )
           # TODO: Stop persisting this

--- a/app/services/collators/childcare_collator.rb
+++ b/app/services/collators/childcare_collator.rb
@@ -3,16 +3,15 @@ module Collators
     Result = Data.define(:cash, :bank)
 
     class << self
-      def call(childcare_outgoings:, gross_income_summary:, eligible_for_childcare:, assessment_errors:)
-        new(childcare_outgoings:, gross_income_summary:, eligible_for_childcare:, assessment_errors:).call
+      def call(childcare_outgoings:, gross_income_summary:, eligible_for_childcare:)
+        new(childcare_outgoings:, gross_income_summary:, eligible_for_childcare:).call
       end
     end
 
-    def initialize(childcare_outgoings:, gross_income_summary:, eligible_for_childcare:, assessment_errors:)
+    def initialize(childcare_outgoings:, gross_income_summary:, eligible_for_childcare:)
       @childcare_outgoings = childcare_outgoings
       @gross_income_summary = gross_income_summary
       @eligible_for_childcare = eligible_for_childcare
-      @assessment_errors = assessment_errors
     end
 
     def call
@@ -28,7 +27,6 @@ module Collators
 
     def child_care_bank
       Calculators::MonthlyEquivalentCalculator.call(
-        assessment_errors: @assessment_errors,
         collection: @childcare_outgoings,
       )
     end

--- a/app/services/collators/gross_income_collator.rb
+++ b/app/services/collators/gross_income_collator.rb
@@ -109,7 +109,6 @@ module Collators
       result = Hash.new(0.0)
       @gross_income_summary.other_income_sources.each do |source|
         monthly_income = Calculators::MonthlyEquivalentCalculator.call(
-          assessment_errors: @gross_income_summary.assessment.assessment_errors,
           collection: source.other_income_payments,
         )
 

--- a/app/services/collators/legal_aid_collator.rb
+++ b/app/services/collators/legal_aid_collator.rb
@@ -3,7 +3,6 @@ module Collators
     class << self
       def call(disposable_income_summary)
         Calculators::MonthlyEquivalentCalculator.call(
-          assessment_errors: disposable_income_summary.assessment.assessment_errors,
           collection: disposable_income_summary.legal_aid_outgoings,
         )
       end

--- a/app/services/collators/maintenance_collator.rb
+++ b/app/services/collators/maintenance_collator.rb
@@ -3,7 +3,6 @@ module Collators
     class << self
       def call(disposable_income_summary)
         Calculators::MonthlyEquivalentCalculator.call(
-          assessment_errors: disposable_income_summary.assessment.assessment_errors,
           collection: disposable_income_summary.maintenance_outgoings,
         )
       end

--- a/app/services/collators/outgoings_collator.rb
+++ b/app/services/collators/outgoings_collator.rb
@@ -7,7 +7,6 @@ module Collators
         # sets child_care_bank and child_care_cash fields in disposable_income_summary
         child_care = Collators::ChildcareCollator.call(gross_income_summary:,
                                                        childcare_outgoings: disposable_income_summary.childcare_outgoings,
-                                                       assessment_errors: disposable_income_summary.assessment.assessment_errors,
                                                        eligible_for_childcare:)
         # TODO: Return these values instead of persisting them
         disposable_income_summary.update!(child_care_bank: child_care.bank, child_care_cash: child_care.cash)

--- a/db/migrate/20230414114501_drop_assessment_errors.rb
+++ b/db/migrate/20230414114501_drop_assessment_errors.rb
@@ -1,0 +1,6 @@
+class DropAssessmentErrors < ActiveRecord::Migration[7.0]
+  def change
+    drop_table :assessment_errors do
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -24,7 +24,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_03_31_170201) do
     t.boolean "self_employed", default: false
     t.boolean "employed"
     t.boolean "receives_asylum_support", default: false, null: false
-    t.index ["assessment_id"], name: "index_applicants_on_assessment_id"
+    t.index ["assessment_id"], name: "index_applicants_on_assessment_id", unique: true
   end
 
   create_table "assessment_errors", force: :cascade do |t|
@@ -215,7 +215,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_03_31_170201) do
     t.uuid "assessment_id", null: false
     t.date "date_of_birth"
     t.boolean "employed"
-    t.index ["assessment_id"], name: "index_partners_on_assessment_id"
+    t.index ["assessment_id"], name: "index_partners_on_assessment_id", unique: true
   end
 
   create_table "proceeding_types", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_03_31_170201) do
+ActiveRecord::Schema[7.0].define(version: 2023_04_14_114501) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -25,14 +25,6 @@ ActiveRecord::Schema[7.0].define(version: 2023_03_31_170201) do
     t.boolean "employed"
     t.boolean "receives_asylum_support", default: false, null: false
     t.index ["assessment_id"], name: "index_applicants_on_assessment_id", unique: true
-  end
-
-  create_table "assessment_errors", force: :cascade do |t|
-    t.uuid "assessment_id", null: false
-    t.uuid "record_id"
-    t.string "record_type"
-    t.string "error_message"
-    t.index ["assessment_id"], name: "index_assessment_errors_on_assessment_id"
   end
 
   create_table "assessments", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
@@ -300,7 +292,6 @@ ActiveRecord::Schema[7.0].define(version: 2023_03_31_170201) do
   end
 
   add_foreign_key "applicants", "assessments"
-  add_foreign_key "assessment_errors", "assessments"
   add_foreign_key "capital_items", "capital_summaries"
   add_foreign_key "capital_summaries", "assessments"
   add_foreign_key "cash_transaction_categories", "gross_income_summaries"

--- a/spec/services/calculators/monthly_income_converter_spec.rb
+++ b/spec/services/calculators/monthly_income_converter_spec.rb
@@ -9,15 +9,8 @@ module Calculators
     context "monthly" do
       let(:frequency) { :monthly }
 
-      describe "error?" do
-        it "returns false" do
-          expect(converter.error?).to be false
-        end
-      end
-
       describe "monthly_amount" do
         it "returns the average monthly amount" do
-          converter.error?
           expect(converter.monthly_amount).to eq 204.48
         end
       end
@@ -26,15 +19,8 @@ module Calculators
     context "four_weekly" do
       let(:frequency) { :four_weekly }
 
-      describe "error?" do
-        it "returns false" do
-          expect(converter.error?).to be false
-        end
-      end
-
       describe "monthly_amount" do
         it "returns the average for the calendar month" do
-          converter.error?
           expect(converter.monthly_amount).to eq 221.52
         end
       end
@@ -43,15 +29,8 @@ module Calculators
     context "two_weekly" do
       let(:frequency) { :two_weekly }
 
-      describe "error?" do
-        it "returns false" do
-          expect(converter.error?).to be false
-        end
-      end
-
       describe "monthly_amount" do
         it "returns the average for the calendar month" do
-          converter.error?
           expect(converter.monthly_amount).to eq 443.04
         end
       end
@@ -60,15 +39,8 @@ module Calculators
     context "weekly" do
       let(:frequency) { :weekly }
 
-      describe "error?" do
-        it "returns false" do
-          expect(converter.error?).to be false
-        end
-      end
-
       describe "monthly_amount" do
         it "returns the average for the calendar month" do
-          converter.error?
           expect(converter.monthly_amount).to eq 886.08
         end
       end
@@ -78,15 +50,8 @@ module Calculators
       let(:frequency) { :unknown }
       let(:payments) { [203.44, 205.00, 205.00, 178.77, 290.12] }
 
-      describe "error?" do
-        it "returns false" do
-          expect(converter.error?).to be false
-        end
-      end
-
       describe "monthly_amount" do
         it "returns the sum of payments divided by 3" do
-          converter.error?
           expect(converter.monthly_amount).to eq 360.78
         end
       end
@@ -96,7 +61,7 @@ module Calculators
       let(:frequency) { :abcd }
 
       it "raises an error" do
-        expect { converter.error? }.to raise_error("Unrecognized frequency")
+        expect { converter.monthly_amount }.to raise_error("Unrecognized frequency")
       end
     end
   end

--- a/spec/services/collators/childcare_collator_spec.rb
+++ b/spec/services/collators/childcare_collator_spec.rb
@@ -16,8 +16,7 @@ module Collators
       end
 
       subject(:collator) do
-        described_class.call(gross_income_summary:, childcare_outgoings:, eligible_for_childcare:,
-                             assessment_errors: assessment.assessment_errors)
+        described_class.call(gross_income_summary:, childcare_outgoings:, eligible_for_childcare:)
       end
 
       before do

--- a/spec/services/cull_stale_assessments_service_spec.rb
+++ b/spec/services/cull_stale_assessments_service_spec.rb
@@ -41,7 +41,6 @@ RSpec.describe CullStaleAssessmentsService do
   def create_assessment_and_associated_records
     ass = create :assessment
     create :applicant, assessment: ass
-    create :assessment_error, assessment: ass
     create_list :dependant, 2, assessment: ass
     create :capital_summary, :with_everything, :with_eligibilities, assessment: ass
     create :gross_income_summary,
@@ -59,7 +58,6 @@ RSpec.describe CullStaleAssessmentsService do
   def associated_models
     [
       Applicant,
-      AssessmentError,
       CapitalItem,
       CapitalSummary,
       CashTransactionCategory,


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/jira/software/c/projects/LEP/boards/1143?modal=detail&selectedIssue=LEP-91)

Describe what you did and why.

1. Created a migration to remove the assessment_errors table
2. Removed assessment_errors from code
3. Removed assessment_errors from the cull stale assessments service 
4. Updated tests 

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
