### PR TITLE
LEP-128 correct type for asset description

### DIFF
--- a/spec/swagger_helper.rb
+++ b/spec/swagger_helper.rb
@@ -255,8 +255,7 @@ RSpec.configure do |config|
               description: "Value of asset",
             },
             description: {
-              type: :number,
-              format: :decimal,
+              type: :string,
               description: "Description of asset",
             },
           },

--- a/swagger/v5/swagger.yaml
+++ b/swagger/v5/swagger.yaml
@@ -267,8 +267,7 @@ components:
         format: decimal
         description: Value of asset
       description:
-        type: number
-        format: decimal
+        type: string
         description: Description of asset
     Employments:
       type: array


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/LEP-128)

Describe what you did and why.

- Corrected the type for asset description from numeric to string
- Removed decimal formatting

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
