### PR TITLE
Pin pg gem to < 1.5 due to rails incompatibility

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,7 +7,8 @@ gem "active_model_serializers", "~> 0.10.13"
 # Bundle edge Rails instead: gem 'rails', github: 'rails/rails'
 gem "rails", "~> 7.0.4", ">= 7.0.4.3"
 # Use postgresql as the database for Active Record
-gem "pg", ">= 0.18", "< 2.0"
+# pg 1.5 introduces a deprecation warning that hasn't been fixed in Rails yet
+gem "pg", "< 1.5"
 # Use Puma as the app server
 gem "puma", "~> 6.2"
 # Build JSON APIs with ease. Read more: https://github.com/rails/jbuilder

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -309,7 +309,7 @@ GEM
       ast (~> 2.4.1)
     patience_diff (1.2.0)
       optimist (~> 3.0)
-    pg (1.5.2)
+    pg (1.4.6)
     pry (0.14.2)
       coderay (~> 1.1)
       method_source (~> 1.0)
@@ -528,7 +528,7 @@ DEPENDENCIES
   net-imap
   net-pop
   net-smtp
-  pg (>= 0.18, < 2.0)
+  pg (< 1.5)
   pry-byebug
   pry-rescue
   pry-stack_explorer


### PR DESCRIPTION
dependabot recently updated the pg gem to 1.5.x, however the rails adapter uses a method which is deprecated in this version. 
Pin it back to pre-1.5 until rails gets around to fixing it - lots of warning messages when running tests otherwise