### PR TITLE
LEP-134  Allow employment with no payments

### DIFF
--- a/app/services/calculators/employment_income_calculator.rb
+++ b/app/services/calculators/employment_income_calculator.rb
@@ -51,6 +51,8 @@ module Calculators
     end
 
     def allowance
+      return 0.0 if @employment.present? && @employment.employment_payments.empty?
+
       @employment.present? && !@employment.receiving_only_statutory_sick_or_maternity_pay? ? fixed_employment_allowance : 0.0
     end
 

--- a/app/services/remark_generators/frequency_checker.rb
+++ b/app/services/remark_generators/frequency_checker.rb
@@ -3,7 +3,7 @@ module RemarkGenerators
     include Exemptable
 
     def self.call(assessment, collection, date_attribute = :payment_date)
-      new(assessment, collection).call(date_attribute)
+      new(assessment, collection).call(date_attribute) unless collection.empty?
     end
 
     def call(date_attribute = :payment_date)

--- a/app/services/remark_generators/orchestrator.rb
+++ b/app/services/remark_generators/orchestrator.rb
@@ -53,7 +53,7 @@ module RemarkGenerators
         FrequencyChecker.call(@assessment, collection)
       end
       assessment.employments.each do |job|
-        FrequencyChecker.call(@assessment, job.employment_payments, :date) if job.employment_payments.any?
+        FrequencyChecker.call(@assessment, job.employment_payments, :date)
       end
     end
 

--- a/app/services/remark_generators/orchestrator.rb
+++ b/app/services/remark_generators/orchestrator.rb
@@ -53,7 +53,7 @@ module RemarkGenerators
         FrequencyChecker.call(@assessment, collection)
       end
       assessment.employments.each do |job|
-        FrequencyChecker.call(@assessment, job.employment_payments, :date)
+        FrequencyChecker.call(@assessment, job.employment_payments, :date) if job.employment_payments.any?
       end
     end
 

--- a/spec/requests/employments_controller_spec.rb
+++ b/spec/requests/employments_controller_spec.rb
@@ -13,15 +13,59 @@ RSpec.describe EmploymentsController, type: :request do
     context "valid payload" do
       context "with client ids" do
         context "with two employments" do
+          context "with income payments" do
+            it "returns http success" do
+              post_payload
+              expect(response).to have_http_status(:success)
+            end
+
+            it "creates two employment income records with associated EmploymentPayment records" do
+              post_payload
+              expect(Employment.count).to eq 2
+              expect(EmploymentPayment.count).to eq 6
+            end
+
+            it "generates a valid response" do
+              post_payload
+              expect(parsed_response[:success]).to eq true
+              expect(parsed_response[:errors]).to be_empty
+            end
+          end
+
+          context "without income payments" do
+            let(:params) { employment_income_without_payments_params }
+
+            it "returns http success" do
+              post_payload
+              expect(response).to have_http_status(:success)
+            end
+
+            it "creates two employment income records with 0 EmploymentPayment records" do
+              post_payload
+              expect(Employment.count).to eq 2
+              expect(EmploymentPayment.count).to eq 0
+            end
+
+            it "generates a valid response" do
+              post_payload
+              expect(parsed_response[:success]).to eq true
+              expect(parsed_response[:errors]).to be_empty
+            end
+          end
+        end
+
+        context "with no employments" do
+          let(:params) { { employment_income: [] } }
+
           it "returns http success" do
             post_payload
             expect(response).to have_http_status(:success)
           end
 
-          it "creates two employment income records with associated EmploymentPayment records" do
+          it "doesn't creates employment income records with associated EmploymentPayment records" do
             post_payload
-            expect(Employment.count).to eq 2
-            expect(EmploymentPayment.count).to eq 6
+            expect(Employment.count).to eq 0
+            expect(EmploymentPayment.count).to eq 0
           end
 
           it "generates a valid response" do
@@ -218,6 +262,23 @@ RSpec.describe EmploymentsController, type: :request do
                 national_insurance: -18.66,
               },
             ],
+          },
+        ],
+      }
+    end
+
+    def employment_income_without_payments_params
+      {
+        employment_income: [
+          {
+            name: "Job 1",
+            client_id: SecureRandom.uuid,
+            payments: [],
+          },
+          {
+            name: "Job 2",
+            client_id: SecureRandom.uuid,
+            payments: [],
           },
         ],
       }

--- a/spec/requests/v6/assessments_controller_spec.rb
+++ b/spec/requests/v6/assessments_controller_spec.rb
@@ -35,6 +35,15 @@ module V6
           },
         ]
       end
+      let(:employment_income_without_payments_params) do
+        [
+          {
+            name: "Job 1",
+            client_id: SecureRandom.uuid,
+            payments: [],
+          },
+        ]
+      end
       let(:vehicle_params) do
         [
           attributes_for(:vehicle, value: 2638.69, loan_amount_outstanding: 3907.77,
@@ -429,6 +438,50 @@ module V6
                         net_employment_income: 739.84,
                       },
                     ],
+                  },
+                ],
+              )
+            end
+          end
+        end
+      end
+
+      context "with employment income without payments" do
+        let(:employed) { true }
+        let(:params) { { employment_income: employment_income_without_payments_params } }
+
+        it "returns http success" do
+          expect(response).to have_http_status(:success)
+        end
+
+        describe "disposable_income from summary" do
+          let(:employment_income) { parsed_response.dig(:result_summary, :disposable_income, :employment_income) }
+
+          it "has employment income" do
+            expect(employment_income)
+              .to eq(
+                {
+                  gross_income: 0.0,
+                  benefits_in_kind: 0.0,
+                  tax: 0.0,
+                  national_insurance: 0.0,
+                  fixed_employment_deduction: -45.0,
+                  net_employment_income: 0,
+                },
+              )
+          end
+        end
+
+        describe "assessment" do
+          describe "gross income" do
+            let(:gross_income) { assessment.fetch(:gross_income) }
+
+            it "has employment income" do
+              expect(gross_income.fetch(:employment_income)).to eq(
+                [
+                  {
+                    name: "Job 1",
+                    payments: [],
                   },
                 ],
               )

--- a/spec/requests/v6/assessments_controller_spec.rb
+++ b/spec/requests/v6/assessments_controller_spec.rb
@@ -40,6 +40,7 @@ module V6
           {
             name: "Job 1",
             client_id: SecureRandom.uuid,
+            receiving_only_statutory_sick_or_maternity_pay: true,
             payments: [],
           },
         ]
@@ -465,8 +466,8 @@ module V6
                   benefits_in_kind: 0.0,
                   tax: 0.0,
                   national_insurance: 0.0,
-                  fixed_employment_deduction: -45.0,
-                  net_employment_income: 0,
+                  fixed_employment_deduction: 0.0,
+                  net_employment_income: 0.0,
                 },
               )
           end

--- a/spec/requests/v6/assessments_controller_spec.rb
+++ b/spec/requests/v6/assessments_controller_spec.rb
@@ -40,7 +40,6 @@ module V6
           {
             name: "Job 1",
             client_id: SecureRandom.uuid,
-            receiving_only_statutory_sick_or_maternity_pay: true,
             payments: [],
           },
         ]
@@ -448,7 +447,6 @@ module V6
       end
 
       context "with employment income without payments" do
-        let(:employed) { true }
         let(:params) { { employment_income: employment_income_without_payments_params } }
 
         it "returns http success" do
@@ -458,7 +456,7 @@ module V6
         describe "disposable_income from summary" do
           let(:employment_income) { parsed_response.dig(:result_summary, :disposable_income, :employment_income) }
 
-          it "has employment income" do
+          it "has employment income with 0 deductions" do
             expect(employment_income)
               .to eq(
                 {
@@ -470,23 +468,6 @@ module V6
                   net_employment_income: 0.0,
                 },
               )
-          end
-        end
-
-        describe "assessment" do
-          describe "gross income" do
-            let(:gross_income) { assessment.fetch(:gross_income) }
-
-            it "has employment income" do
-              expect(gross_income.fetch(:employment_income)).to eq(
-                [
-                  {
-                    name: "Job 1",
-                    payments: [],
-                  },
-                ],
-              )
-            end
           end
         end
       end

--- a/spec/swagger_helper.rb
+++ b/spec/swagger_helper.rb
@@ -201,8 +201,7 @@ RSpec.configure do |config|
           },
           EmploymentPaymentList: {
             type: :array,
-            description: "One or more employment payment details",
-            minItems: 1,
+            description: "0 or more employment payment details",
             items: {
               type: :object,
               additionalProperties: false,

--- a/swagger/v5/swagger.yaml
+++ b/swagger/v5/swagger.yaml
@@ -214,8 +214,7 @@ components:
                 type: boolean
     EmploymentPaymentList:
       type: array
-      description: One or more employment payment details
-      minItems: 1
+      description: 0 or more employment payment details
       items:
         type: object
         additionalProperties: false


### PR DESCRIPTION
## What

[LEP-134](https://dsdmoj.atlassian.net/browse/LEP-134)

- Allow empty payments, in the API ‘employment_income’ section request
- Make it work for V5 and V6 API


[LEP-134]: https://dsdmoj.atlassian.net/browse/LEP-134?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ