### PR TITLE
LEP-10 mark main-home as optional request parameter

### DIFF
--- a/spec/requests/properties_controller_spec.rb
+++ b/spec/requests/properties_controller_spec.rb
@@ -68,16 +68,16 @@ RSpec.describe PropertiesController, type: :request do
     context "with missing main_home attribute" do
       let(:request_payload) { { properties: {} } }
 
-      it "returns http status 422" do
-        expect(response).to have_http_status(:unprocessable_entity)
+      it "returns http status code 200" do
+        expect(response).to have_http_status(:success)
       end
 
-      it "parsed response returns success false" do
-        expect(parsed_response[:success]).to eq false
+      it "parsed response returns success true" do
+        expect(parsed_response[:success]).to eq true
       end
 
-      it "returns expected error response" do
-        expect(parsed_response[:errors]).to match [/The property '#\/properties' did not contain a required property of 'main_home'/]
+      it "parsed response returns no errors" do
+        expect(parsed_response[:errors]).to be_empty
       end
     end
 

--- a/spec/requests/swagger_docs/v5/full_assessment_spec.rb
+++ b/spec/requests/swagger_docs/v5/full_assessment_spec.rb
@@ -43,7 +43,7 @@ RSpec.describe "full_assessment", :calls_bank_holiday, type: :request, swagger_d
                     outgoings: { "$ref" => "#/components/schemas/OutgoingsList" },
                     properties: {
                       type: :object,
-                      required: %i[main_home],
+                      required: %i[],
                       description: "A main home and additional properties",
                       properties: {
                         main_home: { "$ref" => "#/components/schemas/Property" },

--- a/spec/requests/swagger_docs/v5/properties_spec.rb
+++ b/spec/requests/swagger_docs/v5/properties_spec.rb
@@ -18,13 +18,11 @@ RSpec.describe "properties", type: :request, swagger_doc: "v5/swagger.yaml" do
                 required: true,
                 schema: {
                   type: :object,
-                  required: %i[properties],
                   description: "A set consisting of a main home and additional properties",
                   example: JSON.parse(File.read(Rails.root.join("spec/fixtures/properties.json"))),
                   properties: {
                     properties: {
                       type: :object,
-                      required: %i[main_home],
                       description: "A main home and additional properties",
                       properties: {
                         main_home: { "$ref" => "#/components/schemas/Property" },

--- a/spec/requests/swagger_docs/v5/properties_spec.rb
+++ b/spec/requests/swagger_docs/v5/properties_spec.rb
@@ -18,6 +18,7 @@ RSpec.describe "properties", type: :request, swagger_doc: "v5/swagger.yaml" do
                 required: true,
                 schema: {
                   type: :object,
+                  required: %i[properties],
                   description: "A set consisting of a main home and additional properties",
                   example: JSON.parse(File.read(Rails.root.join("spec/fixtures/properties.json"))),
                   properties: {

--- a/spec/requests/v6/assessments_controller_spec.rb
+++ b/spec/requests/v6/assessments_controller_spec.rb
@@ -995,58 +995,82 @@ module V6
             describe "has properties" do
               let(:properties) { capital_items.fetch(:properties) }
 
-              it "has a main home" do
-                expect(properties.fetch(:main_home))
-                  .to eq({
-                    value: 500_000.0,
-                    outstanding_mortgage: 200.0,
-                    percentage_owned: 15.0,
-                    main_home: true,
-                    shared_with_housing_assoc: true,
-                    transaction_allowance: 15_000.0,
-                    allowable_outstanding_mortgage: 200.0,
-                    net_value: 484_800.0,
-                    net_equity: 59_800.0,
-                    main_home_equity_disregard: 59_800.0,
-                    assessed_equity: 0.0,
-                    smod_allowance: 0.0,
-                  })
+              context "without main home" do
+                let(:params) { { properties: {} } }
+
+                it "has a main home with 0 values" do
+                  expect(properties.fetch(:main_home))
+                    .to eq({
+                      value: 0.0,
+                      outstanding_mortgage: 0.0,
+                      percentage_owned: 0,
+                      main_home: false,
+                      shared_with_housing_assoc: false,
+                      transaction_allowance: 0.0,
+                      allowable_outstanding_mortgage: 0.0,
+                      net_value: 0.0,
+                      net_equity: 0.0,
+                      smod_allowance: 0,
+                      main_home_equity_disregard: 0.0,
+                      assessed_equity: 0.0,
+                    })
+                end
               end
 
-              it "has additional properties" do
-                expect(properties.fetch(:additional_properties))
-                  .to match_array(
-                    [
-                      {
-                        value: 1000.0,
-                        outstanding_mortgage: 0.0,
-                        percentage_owned: 99.0,
-                        main_home: false,
-                        shared_with_housing_assoc: false,
-                        transaction_allowance: 30.0,
-                        allowable_outstanding_mortgage: 0.0,
-                        net_value: 970.0,
-                        net_equity: 960.3,
-                        main_home_equity_disregard: 0.0,
-                        assessed_equity: 960.3,
-                        smod_allowance: 0.0,
-                      },
-                      {
-                        value: 10_000.0,
-                        outstanding_mortgage: 40.0,
-                        percentage_owned: 80.0,
-                        main_home: false,
-                        shared_with_housing_assoc: true,
-                        transaction_allowance: 300.0,
-                        allowable_outstanding_mortgage: 40.0,
-                        net_value: 9660.0,
-                        net_equity: 7660.0,
-                        main_home_equity_disregard: 0.0,
-                        assessed_equity: 7660.0,
-                        smod_allowance: 0.0,
-                      },
-                    ],
-                  )
+              context "with main home" do
+                it "has a main home" do
+                  expect(properties.fetch(:main_home))
+                    .to eq({
+                      value: 500_000.0,
+                      outstanding_mortgage: 200.0,
+                      percentage_owned: 15.0,
+                      main_home: true,
+                      shared_with_housing_assoc: true,
+                      transaction_allowance: 15_000.0,
+                      allowable_outstanding_mortgage: 200.0,
+                      net_value: 484_800.0,
+                      net_equity: 59_800.0,
+                      main_home_equity_disregard: 59_800.0,
+                      assessed_equity: 0.0,
+                      smod_allowance: 0.0,
+                    })
+                end
+
+                it "has additional properties" do
+                  expect(properties.fetch(:additional_properties))
+                    .to match_array(
+                      [
+                        {
+                          value: 1000.0,
+                          outstanding_mortgage: 0.0,
+                          percentage_owned: 99.0,
+                          main_home: false,
+                          shared_with_housing_assoc: false,
+                          transaction_allowance: 30.0,
+                          allowable_outstanding_mortgage: 0.0,
+                          net_value: 970.0,
+                          net_equity: 960.3,
+                          main_home_equity_disregard: 0.0,
+                          assessed_equity: 960.3,
+                          smod_allowance: 0.0,
+                        },
+                        {
+                          value: 10_000.0,
+                          outstanding_mortgage: 40.0,
+                          percentage_owned: 80.0,
+                          main_home: false,
+                          shared_with_housing_assoc: true,
+                          transaction_allowance: 300.0,
+                          allowable_outstanding_mortgage: 40.0,
+                          net_value: 9660.0,
+                          net_equity: 7660.0,
+                          main_home_equity_disregard: 0.0,
+                          assessed_equity: 7660.0,
+                          smod_allowance: 0.0,
+                        },
+                      ],
+                    )
+                end
               end
             end
           end

--- a/swagger/v5/swagger.yaml
+++ b/swagger/v5/swagger.yaml
@@ -2083,6 +2083,8 @@ paths:
           application/json:
             schema:
               type: object
+              required:
+              - properties
               description: A set consisting of a main home and additional properties
               example:
                 properties:

--- a/swagger/v5/swagger.yaml
+++ b/swagger/v5/swagger.yaml
@@ -1594,8 +1594,7 @@ paths:
                   "$ref": "#/components/schemas/OutgoingsList"
                 properties:
                   type: object
-                  required:
-                  - main_home
+                  required: []
                   description: A main home and additional properties
                   properties:
                     main_home:
@@ -2084,8 +2083,6 @@ paths:
           application/json:
             schema:
               type: object
-              required:
-              - properties
               description: A set consisting of a main home and additional properties
               example:
                 properties:
@@ -2106,8 +2103,6 @@ paths:
               properties:
                 properties:
                   type: object
-                  required:
-                  - main_home
                   description: A main home and additional properties
                   properties:
                     main_home:


### PR DESCRIPTION
## What

[LEP-10](https://dsdmoj.atlassian.net/browse/LEP-10)

Current code is working without supplying `properties > main_home` parameter. Update API docs to mark `main_home` as optional parameter 

[LEP-10]: https://dsdmoj.atlassian.net/browse/LEP-10?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ