### PR TITLE
LEP-155 bugfix: assessment.dependants is only client dependants

### DIFF
--- a/app/services/creators/eligibilities_creator.rb
+++ b/app/services/creators/eligibilities_creator.rb
@@ -2,7 +2,7 @@ module Creators
   class EligibilitiesCreator
     def self.call(assessment)
       GrossIncomeEligibilityCreator.call(assessment.gross_income_summary,
-                                         assessment.dependants,
+                                         assessment.dependants + assessment.partner_dependants,
                                          assessment.proceeding_types,
                                          assessment.submission_date)
       DisposableIncomeEligibilityCreator.call(assessment)

--- a/spec/factories/assessment_factory.rb
+++ b/spec/factories/assessment_factory.rb
@@ -7,7 +7,7 @@ FactoryBot.define do
     transient do
       # the proceedings transient is an array of arrays, each item comprising a proceeding type code and it's associated client involvement type,
       # e.g. [ ['DA003', 'A'], ['SE014', 'Z']]
-      proceedings { [%w[DA003 A]] }
+      proceedings { [%w[SE003 A]] }
 
       # use :with_child_dependants: 2 to create 2 children for the assessment
       with_child_dependants { 0 }

--- a/spec/factories/dependant_factory.rb
+++ b/spec/factories/dependant_factory.rb
@@ -7,9 +7,19 @@ FactoryBot.define do
     monthly_income { 0.0 }
     assets_value { 0.0 }
 
+    factory :applicant_dependant do
+    end
+
+    factory :partner_dependant do
+    end
+
+    transient do
+      submission_date { assessment.submission_date }
+    end
+
     trait :child_relative do
       relationship { :child_relative }
-      date_of_birth { assessment.submission_date - 16.years + 1.day }
+      date_of_birth { submission_date - 16.years + 1.day }
     end
 
     trait :adult_relative do


### PR DESCRIPTION
https://dsdmoj.atlassian.net/browse/LEP-155

When merging LEP-86, we forgot to notice that assessment.dependants is not the same as Dependant.where(assessment: assessment), as that includes partner dependants too. 

This means that an accidental defect was introduced around the threshold uplift for 4 children - when client (and partner combined) have >4 children, then the gross_income threshold should be raised by a multiplier * (children - 4)