### PR TITLE
Dependabot is producing updates every day which is too often

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,18 +1,14 @@
 version: 2
 updates:
-  - package-ecosystem: bundler
+  - package-ecosystem: "bundler"
     directory: "/"
-    allow:
-      - dependency-type: "all"
     schedule:
-      interval: daily
-      time: "03:00"
-      timezone: Europe/London
-    open-pull-requests-limit: 10
-    ignore:
-      - dependency-name: sentry-raven
-        versions:
-          - 3.1.2
+      interval: "weekly"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
 
   - package-ecosystem: "docker"
     directory: "/"


### PR DESCRIPTION
## What

Reduce frequency of dependabot updates

## Why

Dependabot is updating things every day which is distracting. 
Our sister project CCQ has this parameter set to weekly, which feels like a better tradeoff.

Note that this setting does not include security updates, which are triggered immediately
