### PR TITLE
LEP-157 allow negative gross (and by implication net) employment income

### DIFF
--- a/app/models/employment_payment.rb
+++ b/app/models/employment_payment.rb
@@ -1,13 +1,3 @@
 class EmploymentPayment < ApplicationRecord
   belongs_to :employment
-
-  attribute :net_income
-  before_validation :set_net_income
-  validates :net_income, numericality: { greater_than_or_equal_to: 0 }
-
-private
-
-  def set_net_income
-    self.net_income = gross_income + benefits_in_kind + tax + national_insurance
-  end
 end

--- a/app/services/creators/employments_creator.rb
+++ b/app/services/creators/employments_creator.rb
@@ -11,8 +11,6 @@ module Creators
         ActiveRecord::Base.transaction do
           create_employment employments_params, employment_collection
           Result.new(errors: []).freeze
-        rescue ActiveRecord::RecordInvalid => e
-          Result.new(errors: e.record.errors.full_messages).freeze
         end
       end
 

--- a/spec/models/employment_payment_spec.rb
+++ b/spec/models/employment_payment_spec.rb
@@ -1,7 +1,0 @@
-require "rails_helper"
-
-RSpec.describe EmploymentPayment, type: :model do
-  it "validates net income as positive" do
-    expect(build(:employment_payment, gross_income: 34, tax: -1500.0)).not_to be_valid
-  end
-end

--- a/spec/requests/employments_controller_spec.rb
+++ b/spec/requests/employments_controller_spec.rb
@@ -140,50 +140,6 @@ RSpec.describe EmploymentsController, type: :request do
           expect { post_payload }.not_to change(EmploymentPayment, :count)
         end
       end
-
-      context "negative net income" do
-        let(:params) do
-          {
-            employment_income: [
-              {
-                name: "Job 1",
-                client_id: SecureRandom.uuid,
-                payments: [
-                  {
-                    client_id: SecureRandom.uuid,
-                    date: "2021-10-30",
-                    gross: 46.00,
-                    benefits_in_kind: 16.60,
-                    tax: -104.10,
-                    national_insurance: -18.66,
-                  },
-                  {
-                    client_id: SecureRandom.uuid,
-                    date: "2021-10-30",
-                    gross: 46.00,
-                    benefits_in_kind: 16.60,
-                    tax: -104.10,
-                    national_insurance: -18.66,
-                  },
-                  {
-                    client_id: SecureRandom.uuid,
-                    date: "2021-10-30",
-                    gross: 46.00,
-                    benefits_in_kind: 16.60,
-                    tax: -104.10,
-                    national_insurance: -18.66,
-                  },
-                ],
-              },
-            ],
-          }
-        end
-
-        before { post_payload }
-
-        it_behaves_like "it fails with message",
-                        /Net income must be greater than or equal to 0/
-      end
     end
 
     context "invalid_assessment_id" do

--- a/spec/requests/v6/assessments_controller_spec.rb
+++ b/spec/requests/v6/assessments_controller_spec.rb
@@ -446,6 +446,33 @@ module V6
         end
       end
 
+      context "with negative gross income" do
+        let(:job_with_negative_gross) do
+          [
+            {
+              name: "Job 1",
+              client_id: SecureRandom.uuid,
+              payments: %w[2022-03-30 2022-04-30 2022-05-30].map do |date|
+                {
+                  client_id: SecureRandom.uuid,
+                  gross: -46.00,
+                  benefits_in_kind: 16.60,
+                  tax: -104.10,
+                  national_insurance: -18.66,
+                  date:,
+                }
+              end,
+            },
+          ]
+        end
+
+        let(:params) { { employment_income: job_with_negative_gross } }
+
+        it "is allowed" do
+          expect(response).to have_http_status(:success)
+        end
+      end
+
       context "with employment income without payments" do
         let(:params) { { employment_income: employment_income_without_payments_params } }
 

--- a/spec/services/creators/employments_creator_spec.rb
+++ b/spec/services/creators/employments_creator_spec.rb
@@ -3,30 +3,6 @@ require "rails_helper"
 RSpec.describe Creators::EmploymentsCreator do
   let(:assessment) { create :assessment }
 
-  context "with negative net income" do
-    let(:creator) do
-      described_class.call(employments_params: employment_income_params,
-                           employment_collection: assessment.employments)
-    end
-
-    let(:job1_payments) do
-      [
-        {
-          client_id: "employment-1-payment-1",
-          date: "2021-10-30",
-          gross: 146.00,
-          benefits_in_kind: 16.60,
-          tax: -164.10,
-          national_insurance: -18.66,
-        },
-      ]
-    end
-
-    it "returns an error" do
-      expect(creator.errors).to eq(["Net income must be greater than or equal to 0"])
-    end
-  end
-
   context "with client ids" do
     let(:job1_payments) do
       [

--- a/spec/swagger_helper.rb
+++ b/spec/swagger_helper.rb
@@ -219,7 +219,7 @@ RSpec.configure do |config|
                   example: "1992-07-22",
                 },
                 gross: {
-                  "$ref" => "#/components/schemas/positive_currency",
+                  "$ref" => "#/components/schemas/currency",
                   description: "Gross payment income received",
                   example: "101.01",
                 },

--- a/swagger/v5/swagger.yaml
+++ b/swagger/v5/swagger.yaml
@@ -236,7 +236,7 @@ components:
             description: Date payment received
             example: '1992-07-22'
           gross:
-            "$ref": "#/components/schemas/positive_currency"
+            "$ref": "#/components/schemas/currency"
             description: Gross payment income received
             example: '101.01'
           benefits_in_kind:


### PR DESCRIPTION
https://dsdmoj.atlassian.net/browse/LEP-157

Allow negative gross income on an employment. CFE Classic had a quirk where it allowed through negative gross values if they were submitted as numbers rather than strings. This loosens the validation to allow negative numbers in this field