### PR TITLE
Fix broken dependencies on main branch e2e tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -407,6 +407,8 @@ workflows:
           filters:
             branches:
               only: main
+          requires:
+            - build_and_push
       - integration_tests:
           filters:
             branches:
@@ -427,12 +429,12 @@ workflows:
       - deploy_main_uat:
           context: cfe-civil-uat
           requires:
-            - build_and_push
+            - end2end_tests
       #          <<: *generic-slack-fail-post-step
       - deploy_staging:
           context: cfe-civil-staging
           requires:
-            - build_and_push
+            - end2end_tests
           filters:
             branches:
               only:
@@ -440,7 +442,7 @@ workflows:
       - deploy_production_approval:
           type: approval
           requires:
-            - build_and_push
+            - end2end_tests
           filters:
             branches:
               only:


### PR DESCRIPTION
## What

End2end test dependencies were broken for main. This makes e2e depend on push, and the deployments depend on e2e (rather than push directly) which then depends on all the other steps

## Why

End2end tests had broken dependencies when executed on main branch. Also deployments were not dependant on end2end tests succeeding

