### PR TITLE
Lep 146 log json v6

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,5 +1,5 @@
 class ApplicationController < ActionController::API
-  around_action :log_request
+  around_action :log_request, if: :log_request?
 
   class ErrorSerializer < ApiErrorHandler::Serializers::BaseSerializer
     def serialize(_serializer_options)
@@ -26,13 +26,17 @@ class ApplicationController < ActionController::API
 
   def log_request
     start_time = Time.zone.now
-    rec = RequestLog.create_from_request(request) if /^\/assessment/.match?(request.path)
+    rec = RequestLog.create_from_request(request)
     yield
     duration = Time.zone.now - start_time
-    rec.update_from_response(response, duration) if /^\/assessment/.match?(request.path)
+    rec.update_from_response(response, duration)
   end
 
 private
+
+  def log_request?
+    /^\/v6\/assessment/.match?(request.path)
+  end
 
   def validate_swagger_schema(schema_name, parameters)
     json_validator = JsonSwaggerValidator.new(schema_name, parameters)

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -19,6 +19,7 @@ class ApplicationController < ActionController::API
         http_status: event.payload.fetch(:status),
         response: JSON.parse(event.payload.fetch(:response).body),
         duration: event.duration,
+        user_agent: event.payload.fetch(:headers).fetch("HTTP_USER_AGENT", "unknown"),
       )
     end
   end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,6 +1,4 @@
 class ApplicationController < ActionController::API
-  around_action :log_request, if: :log_request?
-
   class ErrorSerializer < ApiErrorHandler::Serializers::BaseSerializer
     def serialize(_serializer_options)
       { success: false, errors: ["#{@error.class}: #{@error.message}"] }
@@ -13,17 +11,17 @@ class ApplicationController < ActionController::API
 
   handle_api_errors(serializer: ErrorSerializer, error_reporter: :sentry)
 
-  # ActiveSupport::Notifications.subscribe "process_action.action_controller" do |*args|
-  #   event = ActiveSupport::Notifications::Event.new(*args)
-  #   if event.payload.fetch(:controller) == V6::AssessmentsController.to_s
-  #     RequestLog.create!(
-  #       request: event.payload.fetch(:params).except("controller", "action"),
-  #       http_status: event.payload.fetch(:status),
-  #       response: JSON.parse(event.payload.fetch(:response).body),
-  #       duration: event.duration,
-  #     )
-  #   end
-  # end
+  ActiveSupport::Notifications.subscribe "process_action.action_controller" do |*args|
+    event = ActiveSupport::Notifications::Event.new(*args)
+    if event.payload.fetch(:controller) == V6::AssessmentsController.to_s
+      RequestLog.create!(
+        request: event.payload.fetch(:params).except("controller", "action"),
+        http_status: event.payload.fetch(:status),
+        response: JSON.parse(event.payload.fetch(:response).body),
+        duration: event.duration,
+      )
+    end
+  end
 
   def render_unprocessable(message)
     messages = Array.wrap(message)
@@ -36,22 +34,7 @@ class ApplicationController < ActionController::API
     render json: { success: true, errors: [] }
   end
 
-  def log_request
-    start_time = Time.zone.now
-    yield
-    RequestLog.create!(
-      request: request.params.except(:controller, :action),
-      http_status: response.status,
-      response: JSON.parse(response.body),
-      duration: Time.zone.now - start_time,
-    )
-  end
-
 private
-
-  def log_request?
-    /^\/v6\/assessment/.match?(request.path)
-  end
 
   def validate_swagger_schema(schema_name, parameters)
     json_validator = JsonSwaggerValidator.new(schema_name, parameters)

--- a/app/models/assessment.rb
+++ b/app/models/assessment.rb
@@ -36,7 +36,6 @@ class Assessment < ApplicationRecord
            dependent: :destroy
   has_many :proceeding_types,
            dependent: :destroy
-  has_many :request_logs, dependent: :destroy
 
   enum :level_of_help, { certificated: 0, controlled: 1 }
 

--- a/app/models/request_log.rb
+++ b/app/models/request_log.rb
@@ -1,2 +1,3 @@
 class RequestLog < ApplicationRecord
+  validates :request, :response, :user_agent, presence: true
 end

--- a/app/models/request_log.rb
+++ b/app/models/request_log.rb
@@ -1,11 +1,2 @@
 class RequestLog < ApplicationRecord
-  def self.create_from_request(request)
-    create!(request: request.params.except(:controller, :action))
-  end
-
-  def update_from_response(response, duration)
-    update!(http_status: response.status,
-            response: JSON.parse(response.body),
-            duration:)
-  end
 end

--- a/app/models/request_log.rb
+++ b/app/models/request_log.rb
@@ -1,17 +1,11 @@
 class RequestLog < ApplicationRecord
   def self.create_from_request(request)
-    create!(request_method: request.request_method,
-            endpoint: request.path,
-            assessment_id: request.params["assessment_id"] || request.params["id"],
-            params: request.params.to_s)
+    create!(request: request.params.except(:controller, :action))
   end
 
   def update_from_response(response, duration)
-    self.assessment_id = JSON.parse(response.body)["assessment_id"] if assessment_id.nil?
-
-    self.http_status = response.status
-    self.response =  response.body
-    self.duration =  duration
-    save!
+    update!(http_status: response.status,
+            response: JSON.parse(response.body),
+            duration:)
   end
 end

--- a/app/services/decorators/v6/assessment_decorator.rb
+++ b/app/services/decorators/v6/assessment_decorator.rb
@@ -9,12 +9,6 @@ module Decorators
       end
 
       def as_json
-        payload
-      end
-
-    private
-
-      def payload
         {
           version: assessment.version,
           timestamp: Time.current,
@@ -23,6 +17,8 @@ module Decorators
           assessment: assessment_details.transform_values(&:as_json),
         }
       end
+
+    private
 
       def assessment_details
         details = {

--- a/db/migrate/20230525075629_reshape_request_log.rb
+++ b/db/migrate/20230525075629_reshape_request_log.rb
@@ -6,9 +6,11 @@ class ReshapeRequestLog < ActiveRecord::Migration[7.0]
       t.remove :endpoint, type: :string
       t.remove :params, type: :string
       t.remove :response, type: :string
+      t.change_null(:http_status, false)
+      t.change_null(:duration, false)
       t.json :request, null: false
-      t.json :response
-      t.date :created_at
+      t.json :response, null: false
+      t.date :created_at, null: false
     end
   end
 end

--- a/db/migrate/20230525075629_reshape_request_log.rb
+++ b/db/migrate/20230525075629_reshape_request_log.rb
@@ -11,6 +11,7 @@ class ReshapeRequestLog < ActiveRecord::Migration[7.0]
       t.json :request, null: false
       t.json :response, null: false
       t.date :created_at, null: false
+      t.string :user_agent, null: false
     end
   end
 end

--- a/db/migrate/20230525075629_reshape_request_log.rb
+++ b/db/migrate/20230525075629_reshape_request_log.rb
@@ -8,10 +8,10 @@ class ReshapeRequestLog < ActiveRecord::Migration[7.0]
       t.remove :response, type: :string
       t.change_null(:http_status, false)
       t.change_null(:duration, false)
-      t.json :request, null: false
-      t.json :response, null: false
-      t.date :created_at, null: false
-      t.string :user_agent, null: false
+      t.json :request
+      t.json :response
+      t.date :created_at
+      t.string :user_agent
     end
   end
 end

--- a/db/migrate/20230525075629_reshape_request_log.rb
+++ b/db/migrate/20230525075629_reshape_request_log.rb
@@ -1,0 +1,14 @@
+class ReshapeRequestLog < ActiveRecord::Migration[7.0]
+  def change
+    change_table :request_logs, bulk: true do |t|
+      t.remove :assessment_id, type: :string
+      t.remove :request_method, type: :string
+      t.remove :endpoint, type: :string
+      t.remove :params, type: :string
+      t.remove :response, type: :string
+      t.json :request, null: false
+      t.json :response
+      t.date :created_at
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -232,10 +232,10 @@ ActiveRecord::Schema[7.0].define(version: 2023_05_25_075629) do
   create_table "request_logs", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.integer "http_status", null: false
     t.decimal "duration", null: false
-    t.json "request", null: false
-    t.json "response", null: false
-    t.date "created_at", null: false
-    t.string "user_agent", null: false
+    t.json "request"
+    t.json "response"
+    t.date "created_at"
+    t.string "user_agent"
   end
 
   create_table "state_benefit_payments", force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -235,6 +235,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_05_25_075629) do
     t.json "request", null: false
     t.json "response", null: false
     t.date "created_at", null: false
+    t.string "user_agent", null: false
   end
 
   create_table "state_benefit_payments", force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -230,11 +230,11 @@ ActiveRecord::Schema[7.0].define(version: 2023_05_25_075629) do
   end
 
   create_table "request_logs", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
-    t.integer "http_status"
-    t.decimal "duration"
+    t.integer "http_status", null: false
+    t.decimal "duration", null: false
     t.json "request", null: false
-    t.json "response"
-    t.date "created_at"
+    t.json "response", null: false
+    t.date "created_at", null: false
   end
 
   create_table "state_benefit_payments", force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_05_19_124156) do
+ActiveRecord::Schema[7.0].define(version: 2023_05_25_075629) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -230,13 +230,11 @@ ActiveRecord::Schema[7.0].define(version: 2023_05_19_124156) do
   end
 
   create_table "request_logs", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
-    t.string "request_method"
-    t.string "endpoint"
-    t.string "assessment_id"
-    t.string "params"
     t.integer "http_status"
-    t.string "response"
     t.decimal "duration"
+    t.json "request", null: false
+    t.json "response"
+    t.date "created_at"
   end
 
   create_table "state_benefit_payments", force: :cascade do |t|

--- a/spec/requests/v6/assessments_controller_spec.rb
+++ b/spec/requests/v6/assessments_controller_spec.rb
@@ -71,9 +71,9 @@ module V6
       end
       let(:dependant_params) do
         [
-          attributes_for(:dependant, relationship: "child_relative", monthly_income: 0, date_of_birth: "2014-06-11"),
-          attributes_for(:dependant, relationship: "child_relative", monthly_income: 0, date_of_birth: "2013-06-11"),
-          attributes_for(:dependant, relationship: "child_relative", monthly_income: 0, date_of_birth: "2004-06-11"),
+          attributes_for(:dependant, relationship: "child_relative", in_full_time_education: true, monthly_income: 0, date_of_birth: "2014-06-11"),
+          attributes_for(:dependant, relationship: "child_relative", in_full_time_education: true, monthly_income: 0, date_of_birth: "2013-06-11"),
+          attributes_for(:dependant, relationship: "child_relative", in_full_time_education: true, monthly_income: 0, date_of_birth: "2004-06-11"),
         ]
       end
       let(:bank_1) { "#{Faker::Bank.name} #{Faker::Bank.account_number(digits: 8)}" }
@@ -189,6 +189,21 @@ module V6
         it "returns error JSON" do
           expect(parsed_response[:errors]).to include(/Date of birth cannot be in future/)
         end
+
+        it "creates a log record" do
+          expect(RequestLog.last)
+            .to have_attributes(created_at: Time.zone.today,
+                                http_status: 422,
+                                request: {
+                                  "assessment" => { "submission_date" => "2022-06-06" },
+                                  "applicant" => { "has_partner_opponent" => false, "receives_qualifying_benefit" => false, "date_of_birth" => "2900-01-09", "employed" => false },
+                                  "proceeding_types" => [{ "ccms_code" => "DA001", "client_involvement_type" => "A" }],
+                                },
+                                response: {
+                                  "success" => false,
+                                  "errors" => ["Date of birth cannot be in future"],
+                                })
+        end
       end
 
       context "with an dependant error" do
@@ -206,6 +221,7 @@ module V6
 
       context "with dependants" do
         let(:params) { { dependants: dependant_params } }
+        let(:log_record) { RequestLog.last }
 
         it "returns http success" do
           expect(response).to have_http_status(:success)
@@ -219,6 +235,49 @@ module V6
           expect(parsed_response.dig(:result_summary, :disposable_income, :dependant_allowance)).to eq(922.92)
           expect(parsed_response.dig(:result_summary, :disposable_income, :dependant_allowance_under_16)).to eq(615.28)
           expect(parsed_response.dig(:result_summary, :disposable_income, :dependant_allowance_over_16)).to eq(307.64)
+        end
+
+        it "creates a log record" do
+          expect(log_record)
+            .to have_attributes(created_at: Time.zone.today,
+                                http_status: 200,
+                                request: { "assessment" => { "submission_date" => "2022-06-06" },
+                                           "applicant" => { "date_of_birth" => "2001-02-02", "has_partner_opponent" => false, "receives_qualifying_benefit" => false, "employed" => false },
+                                           "proceeding_types" => [{ "ccms_code" => "DA001", "client_involvement_type" => "A" }],
+                                           "dependants" => [{
+                                             "date_of_birth" => "2014-06-11",
+                                             "in_full_time_education" => true,
+                                             "relationship" => "child_relative",
+                                             "monthly_income" => 0,
+                                             "assets_value" => 0.0,
+                                           },
+                                                            {
+                                                              "date_of_birth" => "2013-06-11",
+                                                              "in_full_time_education" => true,
+                                                              "relationship" => "child_relative",
+                                                              "monthly_income" => 0,
+                                                              "assets_value" => 0.0,
+                                                            },
+                                                            { "date_of_birth" => "2004-06-11",
+                                                              "in_full_time_education" => true,
+                                                              "relationship" => "child_relative",
+                                                              "monthly_income" => 0,
+                                                              "assets_value" => 0.0 }] })
+          expect(log_record.response.symbolize_keys.except(:timestamp, :assessment)).to eq(
+            version: "6",
+            success: true,
+            result_summary: {
+              "overall_result" => {
+                "result" => "eligible",
+                "capital_contribution" => 0.0,
+                "income_contribution" => 0.0,
+                "proceeding_types" => [{ "ccms_code" => "DA001", "client_involvement_type" => "A", "upper_threshold" => 0.0, "lower_threshold" => 0.0, "result" => "eligible" }],
+              },
+              "gross_income" => { "total_gross_income" => 0.0, "proceeding_types" => [{ "ccms_code" => "DA001", "client_involvement_type" => "A", "upper_threshold" => 999_999_999_999.0, "lower_threshold" => 0.0, "result" => "eligible" }], "combined_total_gross_income" => 0.0 },
+              "disposable_income" => { "dependant_allowance_under_16" => 615.28, "dependant_allowance_over_16" => 307.64, "dependant_allowance" => 922.92, "gross_housing_costs" => 0.0, "housing_benefit" => 0.0, "net_housing_costs" => 0.0, "maintenance_allowance" => 0.0, "total_outgoings_and_allowances" => 922.92, "total_disposable_income" => -922.92, "employment_income" => { "gross_income" => 0.0, "benefits_in_kind" => 0.0, "tax" => 0.0, "national_insurance" => 0.0, "fixed_employment_deduction" => 0.0, "net_employment_income" => 0.0 }, "income_contribution" => 0.0, "proceeding_types" => [{ "ccms_code" => "DA001", "client_involvement_type" => "A", "upper_threshold" => 999_999_999_999.0, "lower_threshold" => 315.0, "result" => "eligible" }], "combined_total_disposable_income" => -922.92, "combined_total_outgoings_and_allowances" => 922.92, "partner_allowance" => 0 },
+              "capital" => { "pensioner_disregard_applied" => 0.0, "total_liquid" => 0.0, "total_non_liquid" => 0.0, "total_vehicle" => 0.0, "total_property" => 0.0, "total_mortgage_allowance" => 999_999_999_999.0, "total_capital" => 0.0, "subject_matter_of_dispute_disregard" => 0.0, "assessed_capital" => 0.0, "total_capital_with_smod" => 0, "disputed_non_property_disregard" => 0, "proceeding_types" => [{ "ccms_code" => "DA001", "client_involvement_type" => "A", "upper_threshold" => 999_999_999_999.0, "lower_threshold" => 3000.0, "result" => "eligible" }], "combined_disputed_capital" => 0.0, "combined_non_disputed_capital" => 0.0, "capital_contribution" => 0.0, "pensioner_capital_disregard" => 0.0, "combined_assessed_capital" => 0.0 },
+            },
+          )
         end
       end
 

--- a/spec/services/cull_stale_assessments_service_spec.rb
+++ b/spec/services/cull_stale_assessments_service_spec.rb
@@ -44,8 +44,8 @@ RSpec.describe CullStaleAssessmentsService do
       create_list :dependant, 2, assessment: ass
       create :partner, assessment: ass
       create :capital_summary, :with_everything, :with_eligibilities, assessment: ass
-      create :partner_capital_summary, :with_everything, :with_eligibilities, assessment: ass
-      create :partner_capital_summary, :with_everything, :with_eligibilities, assessment: ass
+      create :partner_capital_summary, :with_everything, assessment: ass
+      create :partner_capital_summary, :with_everything, assessment: ass
       create :gross_income_summary,
              :with_all_records,
              :with_employment,
@@ -58,7 +58,6 @@ RSpec.describe CullStaleAssessmentsService do
       create :partner_disposable_income_summary, :with_everything, :with_eligibilities, assessment: ass
       create :explicit_remark, assessment: ass
       create :regular_transaction, gross_income_summary: ass.applicant_gross_income_summary
-      create :request_log, assessment_id: ass.id
     end
   end
 
@@ -84,7 +83,6 @@ RSpec.describe CullStaleAssessmentsService do
       ProceedingType,
       Property,
       RegularTransaction,
-      RequestLog,
       StateBenefitPayment,
       StateBenefit,
       Vehicle,

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -27,7 +27,7 @@ unless ENV["NOCOVERAGE"]
 
     enable_coverage :branch
     primary_coverage :branch
-    minimum_coverage branch: 97.00, line: 99
+    minimum_coverage branch: 98.20, line: 99.92
   end
 end
 


### PR DESCRIPTION
https://dsdmoj.atlassian.net/browse/LEP-146

Log v6 API requests as JSON

Once the v5 controllers have been deleted, the logging code will no longer execute. This updates it, adds a date stamp and de-couples it from the assessment database object so that it can have a separate lifecycle - especially as the long-term vision is for assessments not to be stored at all