### PR TITLE
LEP-98 Mark applicant and partner fields optional

### DIFF
--- a/spec/requests/swagger_docs/v6/full_assessment_spec.rb
+++ b/spec/requests/swagger_docs/v6/full_assessment_spec.rb
@@ -83,7 +83,7 @@ RSpec.describe "full_assessment", :calls_bank_holiday, type: :request, swagger_d
                         partner: {
                           type: :object,
                           description: "The partner of the applicant",
-                          required: %i[date_of_birth employed],
+                          required: %i[date_of_birth],
                           properties: {
                             date_of_birth: {
                               type: :string,
@@ -94,7 +94,7 @@ RSpec.describe "full_assessment", :calls_bank_holiday, type: :request, swagger_d
                             employed: {
                               type: :boolean,
                               example: true,
-                              description: "Whether the applicant's partner is employed",
+                              description: "Applicant's partner is employed (unused in calculation)",
                             },
                           },
                         },

--- a/spec/requests/swagger_docs/v6/full_assessment_spec.rb
+++ b/spec/requests/swagger_docs/v6/full_assessment_spec.rb
@@ -83,7 +83,7 @@ RSpec.describe "full_assessment", :calls_bank_holiday, type: :request, swagger_d
                         partner: {
                           type: :object,
                           description: "The partner of the applicant",
-                          required: %i[date_of_birth],
+                          required: %i[date_of_birth employed],
                           properties: {
                             date_of_birth: {
                               type: :string,
@@ -94,7 +94,7 @@ RSpec.describe "full_assessment", :calls_bank_holiday, type: :request, swagger_d
                             employed: {
                               type: :boolean,
                               example: true,
-                              description: "Applicant's partner is employed (unused in calculation)",
+                              description: "Applicant's partner is employed",
                             },
                           },
                         },

--- a/spec/requests/v6/assessments_controller_spec.rb
+++ b/spec/requests/v6/assessments_controller_spec.rb
@@ -164,6 +164,22 @@ module V6
         end
       end
 
+      context "with an applicant without partner opponent" do
+        let(:params) do
+          { applicant: { date_of_birth: "2001-02-02",
+                         receives_qualifying_benefit: false,
+                         employed: } }
+        end
+
+        it "returns http success" do
+          expect(response).to have_http_status(:success)
+        end
+
+        it "returns nil for has_partner_opponent" do
+          expect(parsed_response.dig(:assessment, :applicant, :has_partner_opponent)).to be_nil
+        end
+      end
+
       context "with an applicant error" do
         let(:params) do
           { applicant: { has_partner_opponent: false,

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -27,7 +27,7 @@ unless ENV["NOCOVERAGE"]
 
     enable_coverage :branch
     primary_coverage :branch
-    minimum_coverage branch: 98.18, line: 99.92
+    minimum_coverage branch: 98.16, line: 99.92
   end
 end
 

--- a/spec/swagger_helper.rb
+++ b/spec/swagger_helper.rb
@@ -384,7 +384,7 @@ RSpec.configure do |config|
           Applicant: {
             type: :object,
             description: "Object describing pertinent applicant details",
-            required: %i[date_of_birth employed receives_qualifying_benefit],
+            required: %i[date_of_birth receives_qualifying_benefit],
             additionalProperties: false,
             properties: {
               date_of_birth: { type: :string,

--- a/spec/swagger_helper.rb
+++ b/spec/swagger_helper.rb
@@ -384,7 +384,7 @@ RSpec.configure do |config|
           Applicant: {
             type: :object,
             description: "Object describing pertinent applicant details",
-            required: %i[date_of_birth has_partner_opponent receives_qualifying_benefit],
+            required: %i[date_of_birth receives_qualifying_benefit],
             additionalProperties: false,
             properties: {
               date_of_birth: { type: :string,
@@ -394,6 +394,7 @@ RSpec.configure do |config|
               employed: {
                 oneOf: [{ type: :boolean }, { type: :null }],
                 example: true,
+                description: "Applicant is employed (unused in calculation)",
               },
               has_partner_opponent: { type: :boolean,
                                       example: false,

--- a/spec/swagger_helper.rb
+++ b/spec/swagger_helper.rb
@@ -384,7 +384,7 @@ RSpec.configure do |config|
           Applicant: {
             type: :object,
             description: "Object describing pertinent applicant details",
-            required: %i[date_of_birth receives_qualifying_benefit],
+            required: %i[date_of_birth employed receives_qualifying_benefit],
             additionalProperties: false,
             properties: {
               date_of_birth: { type: :string,
@@ -394,7 +394,7 @@ RSpec.configure do |config|
               employed: {
                 oneOf: [{ type: :boolean }, { type: :null }],
                 example: true,
-                description: "Applicant is employed (unused in calculation)",
+                description: "Applicant is employed",
               },
               has_partner_opponent: { type: :boolean,
                                       example: false,

--- a/swagger/v6/swagger.yaml
+++ b/swagger/v6/swagger.yaml
@@ -388,7 +388,6 @@ components:
       description: Object describing pertinent applicant details
       required:
       - date_of_birth
-      - employed
       - receives_qualifying_benefit
       additionalProperties: false
       properties:

--- a/swagger/v6/swagger.yaml
+++ b/swagger/v6/swagger.yaml
@@ -388,6 +388,7 @@ components:
       description: Object describing pertinent applicant details
       required:
       - date_of_birth
+      - employed
       - receives_qualifying_benefit
       additionalProperties: false
       properties:
@@ -401,7 +402,7 @@ components:
           - type: boolean
           - type: 'null'
           example: true
-          description: Applicant is employed (unused in calculation)
+          description: Applicant is employed
         has_partner_opponent:
           type: boolean
           example: false
@@ -1557,6 +1558,7 @@ paths:
                       description: The partner of the applicant
                       required:
                       - date_of_birth
+                      - employed
                       properties:
                         date_of_birth:
                           type: string
@@ -1566,8 +1568,7 @@ paths:
                         employed:
                           type: boolean
                           example: true
-                          description: Applicant's partner is employed (unused in
-                            calculation)
+                          description: Applicant's partner is employed
                     irregular_incomes:
                       "$ref": "#/components/schemas/IrregularIncomePayments"
                     employments:

--- a/swagger/v6/swagger.yaml
+++ b/swagger/v6/swagger.yaml
@@ -388,7 +388,6 @@ components:
       description: Object describing pertinent applicant details
       required:
       - date_of_birth
-      - has_partner_opponent
       - receives_qualifying_benefit
       additionalProperties: false
       properties:
@@ -402,6 +401,7 @@ components:
           - type: boolean
           - type: 'null'
           example: true
+          description: Applicant is employed (unused in calculation)
         has_partner_opponent:
           type: boolean
           example: false
@@ -1557,7 +1557,6 @@ paths:
                       description: The partner of the applicant
                       required:
                       - date_of_birth
-                      - employed
                       properties:
                         date_of_birth:
                           type: string
@@ -1567,7 +1566,8 @@ paths:
                         employed:
                           type: boolean
                           example: true
-                          description: Whether the applicant's partner is employed
+                          description: Applicant's partner is employed (unused in
+                            calculation)
                     irregular_incomes:
                       "$ref": "#/components/schemas/IrregularIncomePayments"
                     employments:


### PR DESCRIPTION
## What

[LEP-98](https://dsdmoj.atlassian.net/browse/LEP-98)

We need to mark following fields as optional/mandatory based on their usage in calculations

- applicants.employed (optional)
- applicant.has_partner_opponent (optional)
- partner.employed (mandatory)


[LEP-98]: https://dsdmoj.atlassian.net/browse/LEP-98?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ