### PR TITLE
Fix applicant and partner factories so they are less time-sensitive

### DIFF
--- a/spec/factories/applicant_factory.rb
+++ b/spec/factories/applicant_factory.rb
@@ -1,7 +1,7 @@
 FactoryBot.define do
   factory :applicant do
     assessment
-    date_of_birth { Faker::Date.between(from: 18.years.ago, to: 70.years.ago) }
+    date_of_birth { Faker::Date.between(from: 18.years.ago, to: 49.years.ago) }
     involvement_type { "applicant" }
     has_partner_opponent { false }
     receives_qualifying_benefit { false }
@@ -15,11 +15,11 @@ FactoryBot.define do
     end
 
     trait :under_pensionable_age do
-      date_of_birth { 59.years.ago.to_date }
+      date_of_birth { 49.years.ago.to_date }
     end
 
     trait :over_pensionable_age do
-      date_of_birth { 61.years.ago.to_date }
+      date_of_birth { 71.years.ago.to_date }
     end
   end
 end

--- a/spec/factories/partner_factory.rb
+++ b/spec/factories/partner_factory.rb
@@ -1,15 +1,15 @@
 FactoryBot.define do
   factory :partner do
     assessment
-    date_of_birth { Faker::Date.between(from: 18.years.ago, to: 59.years.ago) }
+    date_of_birth { Faker::Date.between(from: 18.years.ago, to: 49.years.ago) }
     employed { false }
 
     trait :over_pensionable_age do
-      date_of_birth { 61.years.ago.to_date }
+      date_of_birth { 71.years.ago.to_date }
     end
 
     trait :under_pensionable_age do
-      date_of_birth { 59.years.ago.to_date }
+      date_of_birth { 49.years.ago.to_date }
     end
 
     after(:create) do |partner|


### PR DESCRIPTION
The applicant and partner factories make pensioners based on todays date rather than the assessment date - which means that a couple of tests broke on 8th June 2023. This makes the factories more robust, but does not fix the issue - however it defers it until 2032 which is good enough for now