### PR TITLE
LEP-145 convert relationship: child_relative to DOB check

### DIFF
--- a/app/models/dependant.rb
+++ b/app/models/dependant.rb
@@ -13,7 +13,7 @@ class Dependant
     before: proc { Time.zone.tomorrow }, message: :not_in_the_future
   }
 
-  def becomes_adult_on
+  def becomes_16_on
     date_of_birth.years_since(16)
   end
 

--- a/app/services/calculators/childcare_eligibility_calculator.rb
+++ b/app/services/calculators/childcare_eligibility_calculator.rb
@@ -1,29 +1,23 @@
 module Calculators
   class ChildcareEligibilityCalculator
-    def self.call(applicants:, dependants:, submission_date:)
-      new(applicants:, dependants:, submission_date:).call
-    end
-
-    def initialize(applicants:, dependants:, submission_date:)
-      @applicants = applicants
-      @dependants = dependants
-      @submission_date = submission_date
-    end
-
-    def call
-      at_least_one_child_dependant? && all_applicants_are_employed_or_students?
-    end
-
-  private
-
-    def at_least_one_child_dependant?
-      @dependants.any? do |dependant|
-        @submission_date.before?(dependant.becomes_adult_on)
+    class << self
+      def call(applicants:, dependants:, submission_date:)
+        at_least_one_child_dependant?(dependants:, submission_date:) && all_applicants_are_employed_or_students?(applicants)
       end
-    end
 
-    def all_applicants_are_employed_or_students?
-      @applicants.all? { _1.employed? || _1.is_student? }
+    private
+
+      # The guidance says that it would only be reasonable to claim childcare
+      # for a child 15 or under (which is interpreted as whole years, so < 16)
+      def at_least_one_child_dependant?(dependants:, submission_date:)
+        dependants.any? do |dependant|
+          submission_date.before?(dependant.becomes_16_on)
+        end
+      end
+
+      def all_applicants_are_employed_or_students?(applicants)
+        applicants.all? { _1.employed? || _1.is_student? }
+      end
     end
   end
 end

--- a/spec/models/dependant_spec.rb
+++ b/spec/models/dependant_spec.rb
@@ -24,11 +24,11 @@ RSpec.describe Dependant, type: :model do
     end
   end
 
-  describe "#becomes_adult_on" do
+  describe "#becomes_16_on" do
     let(:dependant) { build(:dependant, date_of_birth: Date.new(2000, 1, 1)) }
 
     it "returns the dependant's 16th birthday" do
-      expect(dependant.becomes_adult_on).to eq Date.new(2016, 1, 1)
+      expect(dependant.becomes_16_on).to eq Date.new(2016, 1, 1)
     end
   end
 end

--- a/spec/services/calculators/childcare_eligibility_calculator_spec.rb
+++ b/spec/services/calculators/childcare_eligibility_calculator_spec.rb
@@ -17,7 +17,7 @@ module Calculators
       end
 
       context "with child dependants, an employed applicant and no partner" do
-        let(:dependants) { [OpenStruct.new(becomes_adult_on: submission_date + 1.year)] }
+        let(:dependants) { [instance_double(Dependant, becomes_16_on: submission_date + 1.year)] }
 
         it "returns true" do
           expect(calculated_result).to eq true
@@ -25,7 +25,7 @@ module Calculators
       end
 
       context "with child dependants, a student applicant and no partner" do
-        let(:dependants) { [OpenStruct.new(becomes_adult_on: submission_date + 1.year)] }
+        let(:dependants) { [instance_double(Dependant, becomes_16_on: submission_date + 1.year)] }
         let(:applicant) { OpenStruct.new(employed?: false, is_student?: true) }
 
         it "returns true" do
@@ -34,7 +34,7 @@ module Calculators
       end
 
       context "with adult dependants, an employed applicant and no partner" do
-        let(:dependants) { [OpenStruct.new(becomes_adult_on: submission_date - 1.year)] }
+        let(:dependants) { [OpenStruct.new(becomes_16_on: submission_date - 1.year)] }
 
         it "returns true" do
           expect(calculated_result).to eq false
@@ -42,7 +42,7 @@ module Calculators
       end
 
       context "with child dependants, an employed applicant and an employed partner" do
-        let(:dependants) { [OpenStruct.new(becomes_adult_on: submission_date + 1.year)] }
+        let(:dependants) { [OpenStruct.new(becomes_16_on: submission_date + 1.year)] }
         let(:partner) { OpenStruct.new(employed?: true, is_student?: false) }
 
         it "returns true" do
@@ -51,7 +51,7 @@ module Calculators
       end
 
       context "with child dependants, an employed applicant and an unemployed partner" do
-        let(:dependants) { [OpenStruct.new(becomes_adult_on: submission_date + 1.year)] }
+        let(:dependants) { [OpenStruct.new(becomes_16_on: submission_date + 1.year)] }
         let(:partner) { OpenStruct.new(employed?: false, is_student?: false) }
 
         it "returns true" do


### PR DESCRIPTION
https://dsdmoj.atlassian.net/browse/LEP-145

Renamed #becomes_adult_on to 'becomes_16_on' to better reflect where this is being used (in childcare eligibility, where 16 is considered the threshold for not needing childcare) - nothing about being an 'adult' per se. 

Also removed state from 2 calculations to help move code about later and reduce line count
