### PR TITLE
LEP-207 PersonCapitalSubtotals refactor

### DIFF
--- a/app/services/assessors/capital_item_assessor.rb
+++ b/app/services/assessors/capital_item_assessor.rb
@@ -1,0 +1,6 @@
+module Assessors
+  class CapitalItemAssessor
+    Result = Data.define(:value)
+    CapitalData = Data.define(:capital_item, :result)
+  end
+end

--- a/app/services/assessors/liquid_capital_assessor.rb
+++ b/app/services/assessors/liquid_capital_assessor.rb
@@ -2,7 +2,17 @@ module Assessors
   class LiquidCapitalAssessor
     class << self
       def call(liquid_capital_items)
-        liquid_capital_items.select { _1.value.positive? }.sum(&:value)
+        liquid_capital_items.map { CapitalItemAssessor::CapitalData.new(capital_item: _1, result: result(_1)) }
+      end
+
+    private
+
+      def result(item)
+        if item.value.positive?
+          CapitalItemAssessor::Result.new(value: item.value)
+        else
+          CapitalItemAssessor::Result.new(value: 0)
+        end
       end
     end
   end

--- a/app/services/assessors/non_liquid_capital_assessor.rb
+++ b/app/services/assessors/non_liquid_capital_assessor.rb
@@ -2,7 +2,13 @@ module Assessors
   class NonLiquidCapitalAssessor
     class << self
       def call(non_liquid_capital_items)
-        non_liquid_capital_items.sum(&:value).round(2)
+        non_liquid_capital_items.map { CapitalItemAssessor::CapitalData.new(capital_item: _1, result: result(_1)) }
+      end
+
+    private
+
+      def result(item)
+        CapitalItemAssessor::Result.new(value: item.value)
       end
     end
   end

--- a/app/services/collators/capital_collator.rb
+++ b/app/services/collators/capital_collator.rb
@@ -2,45 +2,25 @@ module Collators
   class CapitalCollator
     class << self
       def call(submission_date:, capital_summary:, pensioner_capital_disregard:, maximum_subject_matter_of_dispute_disregard:, level_of_help:, vehicles:)
-        disputed_liquid = capital_summary.liquid_capital_items.select(&:subject_matter_of_dispute)
-        non_disputed_liquid = capital_summary.liquid_capital_items.reject(&:subject_matter_of_dispute)
-
-        liquid_capital = Assessors::LiquidCapitalAssessor.call(non_disputed_liquid)
-        smod_liquid_capital = Assessors::LiquidCapitalAssessor.call(disputed_liquid)
-
-        disputed_non_liquid = capital_summary.non_liquid_capital_items.select(&:subject_matter_of_dispute)
-        non_disputed_non_liquid = capital_summary.non_liquid_capital_items.reject(&:subject_matter_of_dispute)
-
-        non_liquid_capital = Assessors::NonLiquidCapitalAssessor.call(non_disputed_non_liquid)
-        smod_non_liquid_capital = Assessors::NonLiquidCapitalAssessor.call(disputed_non_liquid)
+        liquid_capital_result = Assessors::LiquidCapitalAssessor.call(capital_summary.liquid_capital_items)
+        non_liquid_capital_result = Assessors::NonLiquidCapitalAssessor.call(capital_summary.non_liquid_capital_items)
 
         properties = Calculators::PropertyCalculator.call(submission_date:,
                                                           properties: capital_summary.properties,
                                                           smod_cap: maximum_subject_matter_of_dispute_disregard,
                                                           level_of_help:)
         property_smod = properties.sum(&:smod_allowance)
-        undisputed_vehicles = Assessors::VehicleAssessor.call(vehicles.reject(&:subject_matter_of_dispute), submission_date)
-        smod_vehicles = Assessors::VehicleAssessor.call(vehicles.select(&:subject_matter_of_dispute), submission_date)
-        vehicle_value = undisputed_vehicles.map(&:result).sum(&:assessed_value)
-        smod_vehicle_value = smod_vehicles.map(&:result).sum(&:assessed_value)
-        non_property_smod_allowance = Calculators::SubjectMatterOfDisputeDisregardCalculator.call(
-          disputed_capital_items: disputed_liquid + disputed_non_liquid,
-          disputed_vehicles: smod_vehicles.map(&:result),
-          maximum_disregard: maximum_subject_matter_of_dispute_disregard - property_smod,
-        )
+        assessed_vehicles = Assessors::VehicleAssessor.call(vehicles, submission_date)
 
         PersonCapitalSubtotals.new(
-          total_liquid: liquid_capital + smod_liquid_capital,
-          total_non_liquid: non_liquid_capital + smod_non_liquid_capital,
-          non_disputed_vehicles: undisputed_vehicles,
-          disputed_vehicles: smod_vehicles,
+          vehicles: assessed_vehicles,
+          properties:,
+          liquid_capital_items: liquid_capital_result,
+          non_liquid_capital_items: non_liquid_capital_result,
           total_mortgage_allowance: property_maximum_mortgage_allowance_threshold(submission_date),
           pensioner_capital_disregard:,
-          disputed_non_property_disregard: non_property_smod_allowance,
           disputed_property_disregard: property_smod,
-          properties:,
-          non_disputed_non_property_capital: liquid_capital + non_liquid_capital + vehicle_value,
-          disputed_non_property_capital: smod_liquid_capital + smod_non_liquid_capital + smod_vehicle_value - non_property_smod_allowance,
+          maximum_smod_disregard: maximum_subject_matter_of_dispute_disregard - property_smod,
         )
       end
 

--- a/spec/services/assessors/liquid_capital_assessor_spec.rb
+++ b/spec/services/assessors/liquid_capital_assessor_spec.rb
@@ -5,32 +5,42 @@ module Assessors
     let(:assessment) { create :assessment, :with_capital_summary }
     let(:capital_summary) { assessment.applicant_capital_summary }
 
+    subject(:liquid_capital_items) do
+      described_class.call(capital_summary.liquid_capital_items).map(&:result).sum(0.0, &:value)
+    end
+
     context "all positive supplied" do
       it "adds them all together" do
         create_list(:liquid_capital_item, 3, capital_summary:)
-        expect(described_class.call(capital_summary.liquid_capital_items)).to eq capital_summary.liquid_capital_items.sum(&:value)
+        expect(liquid_capital_items).to eq capital_summary.liquid_capital_items.sum(&:value)
       end
     end
 
     context "mixture of positive and negative supplied" do
-      it "ignores negative values" do
+      before do
         create :liquid_capital_item, capital_summary:, value: 256.77
         create :liquid_capital_item, capital_summary:, value: -150.33
         create :liquid_capital_item, capital_summary:, value: 67.50
-        expect(described_class.call(capital_summary.liquid_capital_items)).to eq 324.27
+      end
+
+      it "ignores negative values" do
+        expect(liquid_capital_items).to eq 324.27
       end
     end
 
     context "all negative supplied" do
-      it "ignores negative values" do
+      before do
         create_list(:liquid_capital_item, 3, :negative, capital_summary:)
-        expect(described_class.call(capital_summary.liquid_capital_items)).to eq 0.0
+      end
+
+      it "ignores negative values" do
+        expect(liquid_capital_items).to eq 0.0
       end
     end
 
     context "no values supplied" do
       it "returns 0" do
-        expect(described_class.call(capital_summary.liquid_capital_items)).to eq 0.0
+        expect(liquid_capital_items).to eq 0.0
       end
     end
   end

--- a/spec/services/assessors/non_liquid_capital_assessor_spec.rb
+++ b/spec/services/assessors/non_liquid_capital_assessor_spec.rb
@@ -5,19 +5,21 @@ module Assessors
     let(:assessment) { create :assessment, :with_capital_summary }
     let(:capital_summary) { assessment.applicant_capital_summary }
 
+    subject(:non_liquid_total) { described_class.call(capital_summary.non_liquid_capital_items).map(&:result).sum(&:value) }
+
     context "all positive supplied" do
       before do
         create_list :non_liquid_capital_item, 3, capital_summary:
       end
 
       it "adds them all together" do
-        expect(described_class.call(capital_summary.non_liquid_capital_items)).to eq capital_summary.non_liquid_capital_items.sum(&:value)
+        expect(non_liquid_total).to eq capital_summary.non_liquid_capital_items.sum(&:value)
       end
     end
 
     context "no values supplied" do
       it "returns zero" do
-        expect(described_class.call(capital_summary.non_liquid_capital_items)).to eq 0.0
+        expect(non_liquid_total).to eq 0.0
       end
     end
   end


### PR DESCRIPTION
https://dsdmoj.atlassian.net/browse/LEP-207

To improve LEP-207, move the disputed/non-disputed vehicle split **inside** the PersonCapitalSubtotals class, so that the (now) multiple consumers of PersonCapitalSubtotals don't have to do the split themselves