### PR TITLE
Grafana dashboard fixes copied from CCQ

### DIFF
--- a/infrastructure/uat/ingress-dashboard.yaml
+++ b/infrastructure/uat/ingress-dashboard.yaml
@@ -94,11 +94,11 @@ data:
                 "type": "prometheus",
                 "uid": "prometheus"
               },
-              "expr": "sum(rate(nginx_ingress_controller_request_duration_seconds_count{exported_namespace = \"$namespace\", path !~\"/socket.io/.*\", ingress = \"$ingress\"}[5m]))",
+              "expr": "sum(increase(nginx_ingress_controller_request_duration_seconds_count{exported_namespace = \"$namespace\", path !~\"/socket.io/.*\", ingress = \"$ingress\"}[1m])/2)",
               "format": "time_series",
               "interval": "",
               "intervalFactor": 2,
-              "legendFormat": "req / s",
+              "legendFormat": "req / m",
               "refId": "A",
               "step": 60
             }
@@ -189,7 +189,7 @@ data:
                 "type": "prometheus",
                 "uid": "prometheus"
               },
-              "expr": "avg(rate(nginx_ingress_controller_request_duration_seconds_sum{exported_namespace = \"$namespace\", path !~\"/socket.io/.*\", ingress = \"$ingress\"}[5m]) / rate(nginx_ingress_controller_request_duration_seconds_count{exported_namespace = \"$namespace\", path !~\"/socket.io/.*\", ingress = \"$ingress\"}[5m]) > 0)",
+              "expr": "avg(increase(nginx_ingress_controller_request_duration_seconds_sum{exported_namespace = \"$namespace\", path !~\"/socket.io/.*\", ingress = \"$ingress\"}[1m]) / increase(nginx_ingress_controller_request_duration_seconds_count{exported_namespace = \"$namespace\", path !~\"/socket.io/.*\", ingress = \"$ingress\"}[1m]) > 0)/2",
               "format": "time_series",
               "interval": "",
               "intervalFactor": 2,
@@ -278,7 +278,7 @@ data:
           "renderer": "flot",
           "seriesOverrides": [],
           "spaceLength": 10,
-          "stack": true,
+          "stack": false,
           "steppedLine": false,
           "targets": [
             {
@@ -286,7 +286,7 @@ data:
                 "type": "prometheus",
                 "uid": "prometheus"
               },
-              "expr": "sum(rate(nginx_ingress_controller_requests{exported_namespace = \"$namespace\", path !~\"/socket.io/.*\", ingress = \"$ingress\"}[5m])) by (status)",
+              "expr": "sum by (status) (increase(nginx_ingress_controller_requests{exported_namespace = \"$namespace\", path !~\"/socket.io/.*\", ingress = \"$ingress\"}[1m]))/2",
               "format": "time_series",
               "interval": "",
               "intervalFactor": 2,
@@ -376,7 +376,7 @@ data:
           "renderer": "flot",
           "seriesOverrides": [],
           "spaceLength": 10,
-          "stack": true,
+          "stack": false,
           "steppedLine": false,
           "targets": [
             {
@@ -385,7 +385,7 @@ data:
                 "uid": "prometheus"
               },
               "editorMode": "code",
-              "expr": "sum by(status) (increase(nginx_ingress_controller_requests{exported_namespace=\"$namespace\", path!~\"/socket.io/.*\", ingress=\"$ingress\", status=~\"4..|5..\"}[1m]))",
+              "expr": "sum by(status) (increase(nginx_ingress_controller_requests{exported_namespace=\"$namespace\", path!~\"/socket.io/.*\", ingress=\"$ingress\", status=~\"4..|5..\"}[1m])) /2",
               "format": "time_series",
               "interval": "",
               "intervalFactor": 2,
@@ -459,7 +459,7 @@ data:
                 "spanNulls": false,
                 "stacking": {
                   "group": "A",
-                  "mode": "normal"
+                  "mode": "none"
                 },
                 "thresholdsStyle": {
                   "mode": "off"
@@ -584,7 +584,7 @@ data:
                 "type": "prometheus",
                 "uid": "prometheus"
               },
-              "expr": "histogram_quantile(0.95, sum(rate(nginx_ingress_controller_request_duration_seconds_bucket{exported_namespace = \"$namespace\", path !~\"/socket.io/.*\", ingress = \"$ingress\"}[5m])) by (le))",
+              "expr": "histogram_quantile(0.95, sum by (le) (increase(nginx_ingress_controller_request_duration_seconds_bucket{exported_namespace = \"$namespace\", path !~\"/socket.io/.*\", ingress = \"$ingress\"}[1m]))/2)",
               "format": "time_series",
               "interval": "",
               "intervalFactor": 2,
@@ -597,7 +597,7 @@ data:
                 "type": "prometheus",
                 "uid": "prometheus"
               },
-              "expr": "histogram_quantile(0.90, sum(rate(nginx_ingress_controller_request_duration_seconds_bucket{exported_namespace = \"$namespace\", path !~\"/socket.io/.*\",ingress = \"$ingress\"}[5m])) by (le))",
+              "expr": "histogram_quantile(0.90, sum by (le) (increase(nginx_ingress_controller_request_duration_seconds_bucket{exported_namespace = \"$namespace\", path !~\"/socket.io/.*\",ingress = \"$ingress\"}[1m]))/2)",
               "format": "time_series",
               "interval": "",
               "intervalFactor": 2,
@@ -610,7 +610,7 @@ data:
                 "type": "prometheus",
                 "uid": "prometheus"
               },
-              "expr": "histogram_quantile(0.75, sum(rate(nginx_ingress_controller_request_duration_seconds_bucket{exported_namespace = \"$namespace\", path !~\"/socket.io/.*\", ingress = \"$ingress\"}[5m])) by (le))",
+              "expr": "histogram_quantile(0.75, sum by (le) (increase(nginx_ingress_controller_request_duration_seconds_bucket{exported_namespace = \"$namespace\", path !~\"/socket.io/.*\", ingress = \"$ingress\"}[1m]))/2)",
               "format": "time_series",
               "interval": "",
               "intervalFactor": 2,

--- a/infrastructure/uat/pods-dashboard.yaml
+++ b/infrastructure/uat/pods-dashboard.yaml
@@ -224,7 +224,7 @@ data:
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(container_cpu_usage_seconds_total{namespace='$namespace',container='api'}[5m])",
+              "expr": "increase(container_cpu_usage_seconds_total{namespace='$namespace',container='api'}[1m])/2",
               "format": "time_series",
               "intervalFactor": 2,
               "legendFormat": "{{pod}}",
@@ -330,14 +330,14 @@ data:
           "steppedLine": false,
           "targets": [
             {
-              "expr": "avg by(pod_name) (rate(container_network_receive_bytes_total{namespace='$namespace'}[$__rate_interval]))/1024",
+              "expr": "avg by(pod_name) (increase(container_network_receive_bytes_total{namespace='$namespace'}[1m))/2",
               "format": "time_series",
               "intervalFactor": 2,
               "legendFormat": "Avg Bytes Recv/sec",
               "refId": "A"
             },
             {
-              "expr": "avg by(pod_name) (rate(container_network_transmit_bytes_total{namespace='$namespace'}[$__rate_interval]))/1024",
+              "expr": "avg by(pod_name) (increase(container_network_transmit_bytes_total{namespace='$namespace'}[1m]))/2",
               "format": "time_series",
               "intervalFactor": 2,
               "legendFormat": "Avg Bytes Sent/sec",


### PR DESCRIPTION
## What

CCQ did these fixes, and I've directly copied them:
* EL-587/EL-886 fix colours
* EL-589 fix y-axis on rate() panels

When applied they will appear on our Grafana dashboards
* [CFE-Civil ingress](https://grafana.live.cloud-platform.service.justice.gov.uk/d/JC1OFKVbXxSY/cfe-civil-ingress?orgId=1)
* [CFE-Civil pods](https://grafana.live.cloud-platform.service.justice.gov.uk/d/0199b217f65980e0622ba969d1ed1549/cfe-civil-pods?orgId=1)

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
