### PR TITLE
LEP-213 add support for cfe-crime-dev

### DIFF
--- a/infrastructure/uat/ingress-dashboard.yaml
+++ b/infrastructure/uat/ingress-dashboard.yaml
@@ -30,7 +30,7 @@ data:
           }
         ]
       },
-      "description": "CFE Civil Ingress",
+      "description": "CFE Ingress",
       "editable": true,
       "fiscalYearStartMonth": 0,
       "graphTooltip": 1,
@@ -681,7 +681,7 @@ data:
               "refId": "Prometheus-namespace-Variable-Query"
             },
             "refresh": 1,
-            "regex": "/^cfe-civil/",
+            "regex": "/^cfe-(civil|crime-dev)/",
             "skipUrlSync": false,
             "sort": 1,
             "tagValuesQuery": "",
@@ -749,7 +749,7 @@ data:
         ]
       },
       "timezone": "browser",
-      "title": "CFE Civil / Ingress",
+      "title": "CFE / Ingress",
       "uid": "JC1OFKVbXxSY",
       "version": 3,
       "weekStart": ""

--- a/infrastructure/uat/ingress-dashboard.yaml
+++ b/infrastructure/uat/ingress-dashboard.yaml
@@ -30,7 +30,7 @@ data:
           }
         ]
       },
-      "description": "CFE Ingress",
+      "description": "CFE Civil Ingress",
       "editable": true,
       "fiscalYearStartMonth": 0,
       "graphTooltip": 1,
@@ -681,7 +681,7 @@ data:
               "refId": "Prometheus-namespace-Variable-Query"
             },
             "refresh": 1,
-            "regex": "/^cfe-(civil|crime-dev)/",
+            "regex": "/^cfe-civil/",
             "skipUrlSync": false,
             "sort": 1,
             "tagValuesQuery": "",
@@ -749,7 +749,7 @@ data:
         ]
       },
       "timezone": "browser",
-      "title": "CFE / Ingress",
+      "title": "CFE Civil / Ingress",
       "uid": "JC1OFKVbXxSY",
       "version": 3,
       "weekStart": ""

--- a/infrastructure/uat/ingress-dashboard.yaml
+++ b/infrastructure/uat/ingress-dashboard.yaml
@@ -681,7 +681,7 @@ data:
               "refId": "Prometheus-namespace-Variable-Query"
             },
             "refresh": 1,
-            "regex": "/^cfe-(civil|crime-dev)/",
+            "regex": "/^cfe-/",
             "skipUrlSync": false,
             "sort": 1,
             "tagValuesQuery": "",

--- a/infrastructure/uat/pods-dashboard.yaml
+++ b/infrastructure/uat/pods-dashboard.yaml
@@ -450,7 +450,7 @@ data:
         ]
       },
       "timezone": "browser",
-      "title": "CFE Civil / Pods",
+      "title": "CFE / Pods",
       "uid": "0199b217f65980e0622ba969d1ed1549",
       "version": 1
     }

--- a/infrastructure/uat/pods-dashboard.yaml
+++ b/infrastructure/uat/pods-dashboard.yaml
@@ -409,7 +409,7 @@ data:
             "options": [],
             "query": "label_values(kube_deployment_metadata_generation, namespace)",
             "refresh": 1,
-            "regex": "/^cfe-civil/",
+            "regex": "/^cfe-/",
             "skipUrlSync": false,
             "sort": 1,
             "tagValuesQuery": "",

--- a/infrastructure/uat/pods-dashboard.yaml
+++ b/infrastructure/uat/pods-dashboard.yaml
@@ -450,7 +450,7 @@ data:
         ]
       },
       "timezone": "browser",
-      "title": "CFE / Pods",
+      "title": "CFE Civil / Pods",
       "uid": "0199b217f65980e0622ba969d1ed1549",
       "version": 1
     }


### PR DESCRIPTION
[LEP-213](https://dsdmoj.atlassian.net/browse/LEP-213)

- Add 'cfe-crime-dev' in list of namespaces in Grafana dashboards
- Rename title "CFE Civil / Ingress" to "CFE / Ingress"
- Rename title "CFE Civil / pods" to "CFE / pods"

[LEP-213]: https://dsdmoj.atlassian.net/browse/LEP-213?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ