### PR TITLE
Fix bracket in Grafana dashboard

### DIFF
--- a/infrastructure/uat/pods-dashboard.yaml
+++ b/infrastructure/uat/pods-dashboard.yaml
@@ -330,7 +330,7 @@ data:
           "steppedLine": false,
           "targets": [
             {
-              "expr": "avg by(pod_name) (increase(container_network_receive_bytes_total{namespace='$namespace'}[1m))/2",
+              "expr": "avg by(pod_name) (increase(container_network_receive_bytes_total{namespace='$namespace'}[1m]))/2",
               "format": "time_series",
               "intervalFactor": 2,
               "legendFormat": "Avg Bytes Recv/sec",


### PR DESCRIPTION
## What

Fixes this issue showing on the [Pods dashboard](https://grafana.live.cloud-platform.service.justice.gov.uk/d/0199b217f65980e0622ba969d1ed1549/cfe-pods?orgId=1&var-namespace=cfe-crime-dev&inspect=14&inspectTab=error):

![Screenshot 2023-06-20 at 16 15 24](https://github.com/ministryofjustice/cfe-civil/assets/307612/c7ec33c1-5cd1-44f4-b870-8fdd8b52f047)

No story

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
