### PR TITLE
LEP-282: Statutory childcare bug

### DIFF
--- a/app/lib/person_wrapper.rb
+++ b/app/lib/person_wrapper.rb
@@ -2,12 +2,12 @@
 class PersonWrapper
   attr_reader :dependants
 
-  def initialize(is_single:, gross_income_summary:, submission_date:, applicant_person_data:, employments:)
+  def initialize(is_single:, gross_income_summary:, submission_date:, person_data:, employments:)
     @is_single = is_single
-    @dependants = applicant_person_data.dependants
+    @dependants = person_data.dependants
     @gross_income_summary = gross_income_summary
     @submission_date = submission_date
-    @in_work = calculate_in_work(applicant_person_data, employments)
+    @in_work = calculate_in_work(person_data, employments)
   end
 
   def in_work?
@@ -22,9 +22,9 @@ class PersonWrapper
     @is_single
   end
 
-  def calculate_in_work(applicant_person_data, employments)
-    return true if applicant_person_data.self_employments.any?
-    return true if applicant_person_data.employment_details.any? { !_1.income.receiving_only_statutory_sick_or_maternity_pay }
+  def calculate_in_work(person_data, employments)
+    return true if person_data.self_employments.any?
+    return true if person_data.employment_details.any? { !_1.income.receiving_only_statutory_sick_or_maternity_pay }
 
     employments.any? { !_1.receiving_only_statutory_sick_or_maternity_pay }
   end

--- a/app/lib/person_wrapper.rb
+++ b/app/lib/person_wrapper.rb
@@ -2,16 +2,16 @@
 class PersonWrapper
   attr_reader :dependants
 
-  def initialize(employed:, is_single:, dependants:, gross_income_summary:, submission_date:)
-    @employed = employed
+  def initialize(is_single:, gross_income_summary:, submission_date:, applicant_person_data:, employments:)
     @is_single = is_single
-    @dependants = dependants
+    @dependants = applicant_person_data.dependants
     @gross_income_summary = gross_income_summary
     @submission_date = submission_date
+    @in_work = calculate_in_work(applicant_person_data, employments)
   end
 
-  def employed?
-    @employed
+  def in_work?
+    @in_work
   end
 
   def is_student?
@@ -20,5 +20,12 @@ class PersonWrapper
 
   def single?
     @is_single
+  end
+
+  def calculate_in_work(applicant_person_data, employments)
+    return true if applicant_person_data.self_employments.any?
+    return true if applicant_person_data.employment_details.any? { !_1.income.receiving_only_statutory_sick_or_maternity_pay }
+
+    employments.any? { !_1.receiving_only_statutory_sick_or_maternity_pay }
   end
 end

--- a/app/services/calculators/childcare_eligibility_calculator.rb
+++ b/app/services/calculators/childcare_eligibility_calculator.rb
@@ -2,7 +2,7 @@ module Calculators
   class ChildcareEligibilityCalculator
     class << self
       def call(applicants:, dependants:, submission_date:)
-        at_least_one_child_dependant?(dependants:, submission_date:) && all_applicants_are_employed_or_students?(applicants)
+        at_least_one_child_dependant?(dependants:, submission_date:) && all_applicants_are_in_work_or_students?(applicants)
       end
 
     private
@@ -15,8 +15,8 @@ module Calculators
         end
       end
 
-      def all_applicants_are_employed_or_students?(applicants)
-        applicants.all? { _1.employed? || _1.is_student? }
+      def all_applicants_are_in_work_or_students?(applicants)
+        applicants.all? { _1.in_work? || _1.is_student? }
       end
     end
   end

--- a/app/services/workflows/non_passported_workflow.rb
+++ b/app/services/workflows/non_passported_workflow.rb
@@ -146,13 +146,13 @@ module Workflows
       def partner_disposable_income_assessment(assessment:, gross_income_subtotals:, applicant_person_data:, partner_person_data:)
         applicant = PersonWrapper.new is_single: false,
                                       submission_date: assessment.submission_date,
-                                      applicant_person_data:,
+                                      person_data: applicant_person_data,
                                       employments: assessment.employments,
                                       gross_income_summary: assessment.applicant_gross_income_summary
         partner = PersonWrapper.new is_single: false,
                                     submission_date: assessment.submission_date,
                                     gross_income_summary: assessment.partner_gross_income_summary,
-                                    applicant_person_data: partner_person_data,
+                                    person_data: partner_person_data,
                                     employments: assessment.partner_employments
         eligible_for_childcare = calculate_partner_childcare_eligibility(assessment, applicant, partner)
         outgoings = Collators::OutgoingsCollator.call(submission_date: assessment.submission_date,
@@ -199,7 +199,7 @@ module Workflows
       end
 
       def single_disposable_income_assessment(assessment:, gross_income_subtotals:, applicant_person_data:)
-        applicant = PersonWrapper.new applicant_person_data:,
+        applicant = PersonWrapper.new person_data: applicant_person_data,
                                       is_single: true,
                                       submission_date: assessment.submission_date,
                                       gross_income_summary: assessment.applicant_gross_income_summary,

--- a/app/services/workflows/non_passported_workflow.rb
+++ b/app/services/workflows/non_passported_workflow.rb
@@ -37,15 +37,13 @@ module Workflows
         return CalculationOutput.new(gross_income_subtotals:, capital_subtotals: unassessed_capital) if assessment.applicant_gross_income_summary.ineligible?
 
         disposable_income_subtotals = if partner.present?
-                                        partner_disposable_income_assessment(assessment:, gross_income_subtotals:,
-                                                                             dependants: applicant.dependants,
-                                                                             partner_dependants: partner.dependants,
-                                                                             employed: applicant.details.employed,
-                                                                             partner_employed: partner.details.employed)
+                                        partner_disposable_income_assessment(assessment:,
+                                                                             gross_income_subtotals:,
+                                                                             applicant_person_data: applicant,
+                                                                             partner_person_data: partner)
                                       else
                                         single_disposable_income_assessment(assessment:, gross_income_subtotals:,
-                                                                            employed: applicant.details.employed,
-                                                                            dependants: applicant.dependants)
+                                                                            applicant_person_data: applicant)
                                       end
         Assessors::DisposableIncomeAssessor.call(
           disposable_income_summary: assessment.applicant_disposable_income_summary,
@@ -145,13 +143,17 @@ module Workflows
       end
 
       # TODO: make the Collators::DisposableIncomeCollator increment/sum to existing values so order of "collation" becomes unimportant
-      def partner_disposable_income_assessment(assessment:, gross_income_subtotals:, dependants:, partner_dependants:, employed:, partner_employed:)
-        applicant = PersonWrapper.new employed:, is_single: false,
+      def partner_disposable_income_assessment(assessment:, gross_income_subtotals:, applicant_person_data:, partner_person_data:)
+        applicant = PersonWrapper.new is_single: false,
                                       submission_date: assessment.submission_date,
-                                      dependants:, gross_income_summary: assessment.applicant_gross_income_summary
-        partner = PersonWrapper.new employed: partner_employed, is_single: false,
+                                      applicant_person_data:,
+                                      employments: assessment.employments,
+                                      gross_income_summary: assessment.applicant_gross_income_summary
+        partner = PersonWrapper.new is_single: false,
                                     submission_date: assessment.submission_date,
-                                    dependants: partner_dependants, gross_income_summary: assessment.partner_gross_income_summary
+                                    gross_income_summary: assessment.partner_gross_income_summary,
+                                    applicant_person_data: partner_person_data,
+                                    employments: assessment.partner_employments
         eligible_for_childcare = calculate_partner_childcare_eligibility(assessment, applicant, partner)
         outgoings = Collators::OutgoingsCollator.call(submission_date: assessment.submission_date,
                                                       person: applicant,
@@ -196,10 +198,12 @@ module Workflows
         )
       end
 
-      def single_disposable_income_assessment(assessment:, gross_income_subtotals:, dependants:, employed:)
-        applicant = PersonWrapper.new employed:, is_single: true,
+      def single_disposable_income_assessment(assessment:, gross_income_subtotals:, applicant_person_data:)
+        applicant = PersonWrapper.new applicant_person_data:,
+                                      is_single: true,
                                       submission_date: assessment.submission_date,
-                                      dependants:, gross_income_summary: assessment.applicant_gross_income_summary
+                                      gross_income_summary: assessment.applicant_gross_income_summary,
+                                      employments: assessment.employments
         eligible_for_childcare = calculate_childcare_eligibility(assessment, applicant)
         outgoings = Collators::OutgoingsCollator.call(submission_date: assessment.submission_date,
                                                       person: applicant,

--- a/features/employment/statutory_pay.feature
+++ b/features/employment/statutory_pay.feature
@@ -56,7 +56,7 @@ Feature:
             | attribute                      | value      |
             | childcare_allowance            | 0.0        |
 
-    Scenario: The client is receiving statutory sick pay via new income payload structure but has entered childcare costs
+    Scenario: The client is receiving statutory sick pay, input via the newer "employment_details" section, but has entered childcare costs
         Given I am using version 6 of the API
         And I create an assessment with the following details:
             | client_reference_id | NP-FULL-1  |

--- a/features/employment/statutory_pay.feature
+++ b/features/employment/statutory_pay.feature
@@ -23,3 +23,99 @@ Feature:
         Then I should see the following "employment" details:
             | attribute                  | value    |
             | fixed_employment_deduction | 0.0      |
+
+    Scenario: The client is receiving statutory sick pay only but has entered childcare costs
+        Given I am using version 6 of the API
+        And I create an assessment with the following details:
+            | client_reference_id | NP-FULL-1  |
+            | submission_date     | 2023-07-06 |
+        And I add the following applicant details for the current assessment:
+            | date_of_birth               | 1979-12-20 |
+            | involvement_type            | applicant  |
+            | has_partner_opponent        | false      |
+            | receives_qualifying_benefit | false      |
+            | employed                    | true       |
+        And I add the following proceeding types in the current assessment:
+            | ccms_code | client_involvement_type |
+            | SE013     | A                       |
+        And I add the following statutory sick pay details for the client:
+            | client_id |     date     |  gross | benefits_in_kind  | tax   | national_insurance | net_employment_income  |
+            |     C     |  2022-07-22  | 500.50 |       0           | 0.00 |       0.0           |        500.50          |
+            |     C     |  2022-08-22  | 500.50 |       0           | 0.00 |       0.0           |        500.50          |
+            |     C     |  2022-09-22  | 500.50 |       0           | 0.00 |       0.0           |        500.50          |
+        And I add the following outgoing details for "child_care" in the current assessment:
+            | payment_date | client_id | amount |
+            | 2020-02-29   | og-id1    | 200.00 |
+            | 2020-03-27   | og-id2    | 200.00 |
+            | 2020-04-26   | og-id3    | 200.00 |
+        And I add the following dependent details for the current assessment:
+            | date_of_birth | in_full_time_education | relationship   |
+            | 2018-12-20    | FALSE                  | child_relative |
+        When I retrieve the final assessment
+        Then I should see the following "disposable income" details:
+            | attribute                      | value      |
+            | childcare_allowance            | 0.0        |
+
+    Scenario: The client is receiving statutory sick pay via new income payload structure but has entered childcare costs
+        Given I am using version 6 of the API
+        And I create an assessment with the following details:
+            | client_reference_id | NP-FULL-1  |
+            | submission_date     | 2023-07-06 |
+        And I add the following applicant details for the current assessment:
+            | date_of_birth               | 1979-12-20 |
+            | involvement_type            | applicant  |
+            | has_partner_opponent        | false      |
+            | receives_qualifying_benefit | false      |
+            | employed                    | true       |
+        And I add the following proceeding types in the current assessment:
+            | ccms_code | client_involvement_type |
+            | SE013     | A                       |
+        And I add the following "client" employment details in the current assessment:
+            | frequency | gross    | benefits_in_kind | tax  | national_insurance  | receiving_only_statutory_sick_or_maternity_pay |
+            | monthly   | 1200.00  | 0                |  -50 | -30                 | true                                           |
+        And I add the following outgoing details for "child_care" in the current assessment:
+            | payment_date | client_id | amount |
+            | 2020-02-29   | og-id1    | 200.00 |
+            | 2020-03-27   | og-id2    | 200.00 |
+            | 2020-04-26   | og-id3    | 200.00 |
+        And I add the following dependent details for the current assessment:
+            | date_of_birth | in_full_time_education | relationship   |
+            | 2018-12-20    | FALSE                  | child_relative |
+        When I retrieve the final assessment
+        Then I should see the following "disposable income" details:
+            | attribute                      | value      |
+            | childcare_allowance            | 0.0        |
+
+    Scenario: The client is receiving statutory sick pay via new income payload structure but has entered childcare costs
+        Given I am using version 6 of the API
+        And I create an assessment with the following details:
+            | client_reference_id | NP-FULL-1  |
+            | submission_date     | 2023-07-06 |
+        And I add the following applicant details for the current assessment:
+            | date_of_birth               | 1979-12-20 |
+            | involvement_type            | applicant  |
+            | has_partner_opponent        | false      |
+            | receives_qualifying_benefit | false      |
+            | employed                    | true       |
+        And I add the following proceeding types in the current assessment:
+            | ccms_code | client_involvement_type |
+            | SE013     | A                       |
+        And I add the following "client" employment details in the current assessment:
+            | frequency | gross    | benefits_in_kind | tax  | national_insurance  | receiving_only_statutory_sick_or_maternity_pay |
+            | monthly   | 600.00  | 0                |  -50 | -30                 | false                                           |
+        And I add the following "partner" employment details in the current assessment:
+            | frequency | gross    | benefits_in_kind |  tax | national_insurance | receiving_only_statutory_sick_or_maternity_pay |
+            | monthly   | 600.00  | 0                |  -50 | -30                | true                                           |
+        And I add the following outgoing details for "child_care" in the current assessment:
+            | payment_date | client_id | amount |
+            | 2020-02-29   | og-id1    | 200.00 |
+            | 2020-03-27   | og-id2    | 200.00 |
+            | 2020-04-26   | og-id3    | 200.00 |
+        And I add the following dependent details for the current assessment:
+            | date_of_birth | in_full_time_education | relationship   |
+            | 2018-12-20    | FALSE                  | child_relative |
+        When I retrieve the final assessment
+        Then I should see the following "disposable income" details:
+            | attribute                      | value      |
+            | childcare_allowance            | 0.0        |
+

--- a/features/employment/statutory_pay.feature
+++ b/features/employment/statutory_pay.feature
@@ -86,7 +86,7 @@ Feature:
             | attribute                      | value      |
             | childcare_allowance            | 0.0        |
 
-    Scenario: The client is receiving statutory sick pay via new income payload structure but has entered childcare costs
+    Scenario: The partner is receiving statutory sick pay, input via the newer "employment_details" section, but has entered childcare costs
         Given I am using version 6 of the API
         And I create an assessment with the following details:
             | client_reference_id | NP-FULL-1  |

--- a/features/support/response_support_methods.rb
+++ b/features/support/response_support_methods.rb
@@ -4,6 +4,7 @@ RESPONSE_SECTION_MAPPINGS = {
     "capital contribution" => "result_summary.overall_result.capital_contribution",
     "income contribution" => "result_summary.overall_result.income_contribution",
     "disposable_income_summary" => "result_summary.disposable_income",
+    "disposable income" => "assessment.disposable_income",
     "total outgoings and allowances" => "result_summary.disposable_income.combined_total_outgoings_and_allowances",
     "partner allowance" => "result_summary.disposable_income.partner_allowance",
     "dependant allowance" => "result_summary.disposable_income.dependant_allowance",

--- a/spec/services/calculators/childcare_eligibility_calculator_spec.rb
+++ b/spec/services/calculators/childcare_eligibility_calculator_spec.rb
@@ -4,7 +4,7 @@ module Calculators
   RSpec.describe ChildcareEligibilityCalculator do
     describe "#call" do
       let(:dependants) { [] }
-      let(:applicant) { OpenStruct.new(employed?: true, is_student?: false) }
+      let(:applicant) { OpenStruct.new(in_work?: true, is_student?: false) }
       let(:partner) { nil }
       let(:submission_date) { 1.year.ago }
 
@@ -26,7 +26,7 @@ module Calculators
 
       context "with child dependants, a student applicant and no partner" do
         let(:dependants) { [instance_double(Dependant, becomes_16_on: submission_date + 1.year)] }
-        let(:applicant) { OpenStruct.new(employed?: false, is_student?: true) }
+        let(:applicant) { OpenStruct.new(in_work?: false, is_student?: true) }
 
         it "returns true" do
           expect(calculated_result).to eq true
@@ -43,7 +43,7 @@ module Calculators
 
       context "with child dependants, an employed applicant and an employed partner" do
         let(:dependants) { [OpenStruct.new(becomes_16_on: submission_date + 1.year)] }
-        let(:partner) { OpenStruct.new(employed?: true, is_student?: false) }
+        let(:partner) { OpenStruct.new(in_work?: true, is_student?: false) }
 
         it "returns true" do
           expect(calculated_result).to eq true
@@ -52,7 +52,7 @@ module Calculators
 
       context "with child dependants, an employed applicant and an unemployed partner" do
         let(:dependants) { [OpenStruct.new(becomes_16_on: submission_date + 1.year)] }
-        let(:partner) { OpenStruct.new(employed?: false, is_student?: false) }
+        let(:partner) { OpenStruct.new(in_work?: false, is_student?: false) }
 
         it "returns true" do
           expect(calculated_result).to eq false

--- a/spec/services/collators/outgoings_collator_spec.rb
+++ b/spec/services/collators/outgoings_collator_spec.rb
@@ -7,7 +7,7 @@ module Collators
     subject(:collator) do
       described_class.call(submission_date: assessment.submission_date,
                            person: instance_double(PersonWrapper, single?: true,
-                                                                  employed?: false,
+                                                                  in_work?: false,
                                                                   dependants: []),
                            gross_income_summary: assessment.applicant_gross_income_summary,
                            disposable_income_summary: assessment.applicant_disposable_income_summary,


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/LEP-272)

The childcare eligibility calculator was considering only if the applicants were employed when deciding if they were eligible for childcare costs. This was missing the nuance that if either of them is technically employed but receiving only statutory sick/maternity pay, they are not eligible for childcare costs. This PR adds that check.

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
