### PR TITLE
Revert "Bump rswag-api from 2.9.0 to 2.10.1 (#225)"

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -404,7 +404,7 @@ GEM
     rspec-support (3.12.1)
     rspec_junit_formatter (0.6.0)
       rspec-core (>= 2, < 4, != 2.12.0)
-    rswag-api (2.10.1)
+    rswag-api (2.9.0)
       railties (>= 3.1, < 7.1)
     rswag-specs (2.10.1)
       activesupport (>= 3.1, < 7.1)


### PR DESCRIPTION
This reverts commit f62eb19828cd042a77a8f6dc5266e5c41c416a27.
