### PR TITLE
Document "dependent" more fully, based on CCQ content

### DIFF
--- a/spec/requests/swagger_docs/v6/full_assessment_spec.rb
+++ b/spec/requests/swagger_docs/v6/full_assessment_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe "full_assessment", :calls_bank_holiday, type: :request, swagger_d
                     cash_transactions: { "$ref" => components[:cash_transactions] },
                     dependants: {
                       type: :array,
-                      description: "One or more dependants details",
+                      description: "Dependants of the applicant. Defined as someone who lives with the applicant and depends on the applicant for financial support. A child relative is, for example, the applicant's or their partner's child or another child relative, who lives in their household. A child dependant must be either under school leaving age, in full-time education, or undergoing training for a trade, profession or vocation. Do not include foster children. An adult dependant is any adult relative of the applicant, who lives in the same household and is financially dependant on the applicant or their partner. Each dependant should be included only once, in either 'dependants' or 'partner.dependants'",
                       items: { "$ref" => components[:dependant] },
                     },
                     employment_income: { "$ref" => components[:employments] },
@@ -161,7 +161,7 @@ RSpec.describe "full_assessment", :calls_bank_holiday, type: :request, swagger_d
                         },
                         dependants: {
                           type: :array,
-                          description: "One or more dependants details",
+                          description: "Dependants of the applicant's partner. Defined as someone who lives with the applicant and depends on the applicant's partner for financial support. A child relative is, for example, the applicant's or their partner's child or another child relative, who lives in their household. A child dependant must be either under school leaving age, in full-time education, or undergoing training for a trade, profession or vocation. Do not include foster children. An adult dependant is any adult relative of the applicant's partner, who lives in the same household and is financially dependant on the applicant or their partner. Each dependant should be included only once, in either 'dependants' or 'partner.dependants'",
                           items: { "$ref" => components[:dependant] },
                         },
                       },

--- a/spec/requests/swagger_docs/v7/full_assessment_spec.rb
+++ b/spec/requests/swagger_docs/v7/full_assessment_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe "full_assessment", :calls_bank_holiday, type: :request, swagger_d
                     cash_transactions: { "$ref" => components[:cash_transactions] },
                     dependants: {
                       type: :array,
-                      description: "One or more dependants details",
+                      description: "Dependants of the applicant. Defined as someone who lives with the applicant and depends on the applicant for financial support. A child relative is, for example, the applicant's or their partner's child or another child relative, who lives in their household. A child dependant must be either under school leaving age, in full-time education, or undergoing training for a trade, profession or vocation. Do not include foster children. An adult dependant is any adult relative of the applicant, who lives in the same household and is financially dependant on the applicant or their partner. Each dependant should be included only once, in either 'dependants' or 'partner.dependants'",
                       items: { "$ref" => components[:dependant] },
                     },
                     employment_income: { "$ref" => components[:employments] },
@@ -146,7 +146,7 @@ RSpec.describe "full_assessment", :calls_bank_holiday, type: :request, swagger_d
                         },
                         dependants: {
                           type: :array,
-                          description: "One or more dependants details",
+                          description: "Dependants of the applicant's partner. Defined as someone who lives with the applicant and depends on the applicant's partner for financial support. A child relative is, for example, the applicant's or their partner's child or another child relative, who lives in their household. A child dependant must be either under school leaving age, in full-time education, or undergoing training for a trade, profession or vocation. Do not include foster children. An adult dependant is any adult relative of the applicant's partner, who lives in the same household and is financially dependant on the applicant or their partner. Each dependant should be included only once, in either 'dependants' or 'partner.dependants'",
                           items: { "$ref" => components[:dependant] },
                         },
                       },

--- a/swagger/v6/swagger.yaml
+++ b/swagger/v6/swagger.yaml
@@ -1555,7 +1555,17 @@ paths:
                   "$ref": "#/components/schemas/CashTransactions"
                 dependants:
                   type: array
-                  description: One or more dependants details
+                  description: Dependants of the applicant. Defined as someone who
+                    lives with the applicant and depends on the applicant for financial
+                    support. A child relative is, for example, the applicant's or
+                    their partner's child or another child relative, who lives in
+                    their household. A child dependant must be either under school
+                    leaving age, in full-time education, or undergoing training for
+                    a trade, profession or vocation. Do not include foster children.
+                    An adult dependant is any adult relative of the applicant, who
+                    lives in the same household and is financially dependant on the
+                    applicant or their partner. Each dependant should be included
+                    only once, in either 'dependants' or 'partner.dependants'
                   items:
                     "$ref": "#/components/schemas/Dependant"
                 employment_income:
@@ -1753,7 +1763,18 @@ paths:
                         "$ref": "#/components/schemas/Vehicle"
                     dependants:
                       type: array
-                      description: One or more dependants details
+                      description: Dependants of the applicant's partner. Defined
+                        as someone who lives with the applicant and depends on the
+                        applicant's partner for financial support. A child relative
+                        is, for example, the applicant's or their partner's child
+                        or another child relative, who lives in their household. A
+                        child dependant must be either under school leaving age, in
+                        full-time education, or undergoing training for a trade, profession
+                        or vocation. Do not include foster children. An adult dependant
+                        is any adult relative of the applicant's partner, who lives
+                        in the same household and is financially dependant on the
+                        applicant or their partner. Each dependant should be included
+                        only once, in either 'dependants' or 'partner.dependants'
                       items:
                         "$ref": "#/components/schemas/Dependant"
                 explicit_remarks:

--- a/swagger/v7/swagger.yaml
+++ b/swagger/v7/swagger.yaml
@@ -1572,7 +1572,17 @@ paths:
                   "$ref": "#/components/schemas/CashTransactions"
                 dependants:
                   type: array
-                  description: One or more dependants details
+                  description: Dependants of the applicant. Defined as someone who
+                    lives with the applicant and depends on the applicant for financial
+                    support. A child relative is, for example, the applicant's or
+                    their partner's child or another child relative, who lives in
+                    their household. A child dependant must be either under school
+                    leaving age, in full-time education, or undergoing training for
+                    a trade, profession or vocation. Do not include foster children.
+                    An adult dependant is any adult relative of the applicant, who
+                    lives in the same household and is financially dependant on the
+                    applicant or their partner. Each dependant should be included
+                    only once, in either 'dependants' or 'partner.dependants'
                   items:
                     "$ref": "#/components/schemas/Dependant"
                 employment_income:
@@ -1755,7 +1765,18 @@ paths:
                         "$ref": "#/components/schemas/Vehicle"
                     dependants:
                       type: array
-                      description: One or more dependants details
+                      description: Dependants of the applicant's partner. Defined
+                        as someone who lives with the applicant and depends on the
+                        applicant's partner for financial support. A child relative
+                        is, for example, the applicant's or their partner's child
+                        or another child relative, who lives in their household. A
+                        child dependant must be either under school leaving age, in
+                        full-time education, or undergoing training for a trade, profession
+                        or vocation. Do not include foster children. An adult dependant
+                        is any adult relative of the applicant's partner, who lives
+                        in the same household and is financially dependant on the
+                        applicant or their partner. Each dependant should be included
+                        only once, in either 'dependants' or 'partner.dependants'
                       items:
                         "$ref": "#/components/schemas/Dependant"
                 explicit_remarks:


### PR DESCRIPTION
There's a general intention to document the fields in the API well, so we are clear to clients what the fields are for, as the mapping from fields to the guidance is not always straightforward.

There is an argument to deprecate the "partner.dependants" section and just ask for the household in "dependants", but the advantage of doing it separately is that the "partner" section will soon have a definition for what a partner is, and if they are opposing (for example) then it is clear that you do not include dependants being financed by the partner.

No Jira ticket for this. 

---

## Checklist

Before you ask people to review this PR:

- Diff - review it, ensuring it contains only expected changes
- Whitespace changes - avoid if possible, because they make diffs harder to read and conflicts more likely
- Changelog - add a line, if it meets the criteria
- Commit messages - say *why* the change was made
- PR description - summarizes *what* changed and *why*, with a JIRA ticket ID
- Tests pass - on CircleCI
- Conflicts - resolve if Github reports them. e.g. with `git rebase main`
