### PR TITLE
API docs - partner reference to guidance

### DIFF
--- a/app/lib/swagger_docs.rb
+++ b/app/lib/swagger_docs.rb
@@ -463,7 +463,7 @@ class SwaggerDocs
               },
               has_partner_opponent: { type: :boolean,
                                       example: false,
-                                      description: "Deprecated - not used in the calculation. A partner that is an opponent in the case should *not* be included in the request. Definition of 'partner' is described in Lord Chancellor's Certificated Guidance '3.1 Individual and partner' and LC's Controlled Guidance '4.2 Aggregation of Means'",
+                                      description: "Deprecated - not used in the calculation. A partner that is an opponent in the case should *not* be included in the request. For more details, see 'partner'",
                                       deprecated: true },
               receives_qualifying_benefit: { type: :boolean,
                                              example: false,

--- a/app/lib/swagger_docs.rb
+++ b/app/lib/swagger_docs.rb
@@ -461,7 +461,7 @@ class SwaggerDocs
               },
               has_partner_opponent: { type: :boolean,
                                       example: false,
-                                      description: "Applicant has partner opponent (unused in calculation)" },
+                                      description: "Deprecated - not used in the calculation. A partner that is an opponent in the case should *not* be included in the request. Definition of 'partner' is described in Lord Chancellor's Certificated Guidance '3.1 Individual and partner' and LC's Controlled Guidance '4.2 Aggregation of Means'" },
               receives_qualifying_benefit: { type: :boolean,
                                              example: false,
                                              description: "Applicant receives qualifying benefit" },

--- a/app/lib/swagger_docs.rb
+++ b/app/lib/swagger_docs.rb
@@ -300,7 +300,9 @@ class SwaggerDocs
                 },
                 net_employment_income: {
                   "$ref" => SCHEMA_COMPONENTS[:currency],
+                  # NB when using a $ref, the 'description' and 'deprecated' don't get displayed in the swagger web page - they are only visible to clients in the raw swagger.yaml
                   description: "Deprecated field not used in calculation",
+                  deprecated: true,
                 },
               },
             },
@@ -461,7 +463,8 @@ class SwaggerDocs
               },
               has_partner_opponent: { type: :boolean,
                                       example: false,
-                                      description: "Deprecated - not used in the calculation. A partner that is an opponent in the case should *not* be included in the request. Definition of 'partner' is described in Lord Chancellor's Certificated Guidance '3.1 Individual and partner' and LC's Controlled Guidance '4.2 Aggregation of Means'" },
+                                      description: "Deprecated - not used in the calculation. A partner that is an opponent in the case should *not* be included in the request. Definition of 'partner' is described in Lord Chancellor's Certificated Guidance '3.1 Individual and partner' and LC's Controlled Guidance '4.2 Aggregation of Means'",
+                                      deprecated: true },
               receives_qualifying_benefit: { type: :boolean,
                                              example: false,
                                              description: "Applicant receives qualifying benefit" },

--- a/spec/requests/swagger_docs/v6/full_assessment_spec.rb
+++ b/spec/requests/swagger_docs/v6/full_assessment_spec.rb
@@ -89,7 +89,7 @@ RSpec.describe "full_assessment", :calls_bank_holiday, type: :request, swagger_d
                       type: :object,
                       required: %i[partner],
                       additionalProperties: false,
-                      description: "Partner of the applicant's financial and personal info. Definition of 'partner' is described in Lord Chancellor's Certificated Guidance '3.1 Individual and partner' and LC's Controlled Guidance '4.2 Aggregation of Means'",
+                      description: "Partner of the applicant's financial and personal info. Definition of 'partner' that should included in the means test is described in the Lord Chancellor's guidance - certificated: '3.1 Individual and partner', controlled: '4.2 Aggregation of Means'.",
                       example: JSON.parse(File.read(Rails.root.join("spec/fixtures/partner_financials.json"))),
                       properties: {
                         partner: {

--- a/spec/requests/swagger_docs/v6/full_assessment_spec.rb
+++ b/spec/requests/swagger_docs/v6/full_assessment_spec.rb
@@ -89,12 +89,12 @@ RSpec.describe "full_assessment", :calls_bank_holiday, type: :request, swagger_d
                       type: :object,
                       required: %i[partner],
                       additionalProperties: false,
-                      description: "Full information about an applicant's partner",
+                      description: "Partner of the applicant's financial and personal info. Definition of 'partner' is described in Lord Chancellor's Certificated Guidance '3.1 Individual and partner' and LC's Controlled Guidance '4.2 Aggregation of Means'",
                       example: JSON.parse(File.read(Rails.root.join("spec/fixtures/partner_financials.json"))),
                       properties: {
                         partner: {
                           type: :object,
-                          description: "The partner of the applicant",
+                          description: "Partner's personal info",
                           required: %i[date_of_birth],
                           additionalProperties: false,
                           properties: {
@@ -102,7 +102,7 @@ RSpec.describe "full_assessment", :calls_bank_holiday, type: :request, swagger_d
                               type: :string,
                               format: :date,
                               example: "1992-07-22",
-                              description: "Applicant's partner's date of birth",
+                              description: "Partner's date of birth",
                             },
                             employed: {
                               type: :boolean,

--- a/spec/requests/swagger_docs/v7/full_assessment_spec.rb
+++ b/spec/requests/swagger_docs/v7/full_assessment_spec.rb
@@ -86,13 +86,13 @@ RSpec.describe "full_assessment", :calls_bank_holiday, type: :request, swagger_d
                     partner: {
                       type: :object,
                       required: %i[partner],
-                      description: "Full information about an applicant's partner",
+                      description: "Partner of the applicant's financial and personal info. Definition of 'partner' is described in Lord Chancellor's Certificated Guidance '3.1 Individual and partner' and LC's Controlled Guidance '4.2 Aggregation of Means'",
                       example: JSON.parse(File.read(Rails.root.join("spec/fixtures/partner_financials.json"))),
                       additionalProperties: false,
                       properties: {
                         partner: {
                           type: :object,
-                          description: "The partner of the applicant",
+                          description: "Partner's personal info",
                           required: %i[date_of_birth],
                           additionalProperties: false,
                           properties: {
@@ -100,7 +100,7 @@ RSpec.describe "full_assessment", :calls_bank_holiday, type: :request, swagger_d
                               type: :string,
                               format: :date,
                               example: "1992-07-22",
-                              description: "Applicant's partner's date of birth",
+                              description: "Partner's date of birth",
                             },
                             employed: {
                               type: :boolean,

--- a/spec/requests/swagger_docs/v7/full_assessment_spec.rb
+++ b/spec/requests/swagger_docs/v7/full_assessment_spec.rb
@@ -86,7 +86,7 @@ RSpec.describe "full_assessment", :calls_bank_holiday, type: :request, swagger_d
                     partner: {
                       type: :object,
                       required: %i[partner],
-                      description: "Partner of the applicant's financial and personal info. Definition of 'partner' is described in Lord Chancellor's Certificated Guidance '3.1 Individual and partner' and LC's Controlled Guidance '4.2 Aggregation of Means'",
+                      description: "Partner of the applicant's financial and personal info. Definition of 'partner' that should included in the means test is described in the Lord Chancellor's guidance - certificated: '3.1 Individual and partner', controlled: '4.2 Aggregation of Means'.",
                       example: JSON.parse(File.read(Rails.root.join("spec/fixtures/partner_financials.json"))),
                       additionalProperties: false,
                       properties: {

--- a/swagger/v6/swagger.yaml
+++ b/swagger/v6/swagger.yaml
@@ -418,7 +418,11 @@ components:
         has_partner_opponent:
           type: boolean
           example: false
-          description: Applicant has partner opponent (unused in calculation)
+          description: Deprecated - not used in the calculation. A partner that is
+            an opponent in the case should *not* be included in the request. Definition
+            of 'partner' is described in Lord Chancellor's Certificated Guidance '3.1
+            Individual and partner' and LC's Controlled Guidance '4.2 Aggregation
+            of Means'
         receives_qualifying_benefit:
           type: boolean
           example: false
@@ -1868,7 +1872,10 @@ paths:
                   required:
                   - partner
                   additionalProperties: false
-                  description: Full information about an applicant's partner
+                  description: Partner of the applicant's financial and personal info.
+                    Definition of 'partner' is described in Lord Chancellor's Certificated
+                    Guidance '3.1 Individual and partner' and LC's Controlled Guidance
+                    '4.2 Aggregation of Means'
                   example:
                     partner:
                       date_of_birth: '1992-07-22'
@@ -1924,7 +1931,7 @@ paths:
                   properties:
                     partner:
                       type: object
-                      description: The partner of the applicant
+                      description: Partner's personal info
                       required:
                       - date_of_birth
                       additionalProperties: false
@@ -1933,7 +1940,7 @@ paths:
                           type: string
                           format: date
                           example: '1992-07-22'
-                          description: Applicant's partner's date of birth
+                          description: Partner's date of birth
                         employed:
                           type: boolean
                           description: Deprecated - employment is determined by presence

--- a/swagger/v6/swagger.yaml
+++ b/swagger/v6/swagger.yaml
@@ -262,8 +262,9 @@ components:
               can be positive for a refund
             example: -5.24
           net_employment_income:
-            "$ref": "#/components/schemas/currency"
             description: Deprecated field not used in calculation
+            deprecated: true
+            "$ref": "#/components/schemas/currency"
     NonPropertyAsset:
       type: object
       additionalProperties: false
@@ -423,6 +424,7 @@ components:
             of 'partner' is described in Lord Chancellor's Certificated Guidance '3.1
             Individual and partner' and LC's Controlled Guidance '4.2 Aggregation
             of Means'
+          deprecated: true
         receives_qualifying_benefit:
           type: boolean
           example: false

--- a/swagger/v6/swagger.yaml
+++ b/swagger/v6/swagger.yaml
@@ -262,9 +262,9 @@ components:
               can be positive for a refund
             example: -5.24
           net_employment_income:
+            "$ref": "#/components/schemas/currency"
             description: Deprecated field not used in calculation
             deprecated: true
-            "$ref": "#/components/schemas/currency"
     NonPropertyAsset:
       type: object
       additionalProperties: false
@@ -420,10 +420,8 @@ components:
           type: boolean
           example: false
           description: Deprecated - not used in the calculation. A partner that is
-            an opponent in the case should *not* be included in the request. Definition
-            of 'partner' is described in Lord Chancellor's Certificated Guidance '3.1
-            Individual and partner' and LC's Controlled Guidance '4.2 Aggregation
-            of Means'
+            an opponent in the case should *not* be included in the request. For more
+            details, see 'partner'
           deprecated: true
         receives_qualifying_benefit:
           type: boolean
@@ -1874,10 +1872,11 @@ paths:
                   required:
                   - partner
                   additionalProperties: false
-                  description: Partner of the applicant's financial and personal info.
-                    Definition of 'partner' is described in Lord Chancellor's Certificated
-                    Guidance '3.1 Individual and partner' and LC's Controlled Guidance
-                    '4.2 Aggregation of Means'
+                  description: 'Partner of the applicant''s financial and personal
+                    info. Definition of ''partner'' that should included in the means
+                    test is described in the Lord Chancellor''s guidance - certificated:
+                    ''3.1 Individual and partner'', controlled: ''4.2 Aggregation
+                    of Means''.'
                   example:
                     partner:
                       date_of_birth: '1992-07-22'

--- a/swagger/v7/swagger.yaml
+++ b/swagger/v7/swagger.yaml
@@ -262,9 +262,9 @@ components:
               can be positive for a refund
             example: -5.24
           net_employment_income:
+            "$ref": "#/components/schemas/currency"
             description: Deprecated field not used in calculation
             deprecated: true
-            "$ref": "#/components/schemas/currency"
     NonPropertyAsset:
       type: object
       additionalProperties: false
@@ -420,10 +420,8 @@ components:
           type: boolean
           example: false
           description: Deprecated - not used in the calculation. A partner that is
-            an opponent in the case should *not* be included in the request. Definition
-            of 'partner' is described in Lord Chancellor's Certificated Guidance '3.1
-            Individual and partner' and LC's Controlled Guidance '4.2 Aggregation
-            of Means'
+            an opponent in the case should *not* be included in the request. For more
+            details, see 'partner'
           deprecated: true
         receives_qualifying_benefit:
           type: boolean
@@ -1873,10 +1871,11 @@ paths:
                   type: object
                   required:
                   - partner
-                  description: Partner of the applicant's financial and personal info.
-                    Definition of 'partner' is described in Lord Chancellor's Certificated
-                    Guidance '3.1 Individual and partner' and LC's Controlled Guidance
-                    '4.2 Aggregation of Means'
+                  description: 'Partner of the applicant''s financial and personal
+                    info. Definition of ''partner'' that should included in the means
+                    test is described in the Lord Chancellor''s guidance - certificated:
+                    ''3.1 Individual and partner'', controlled: ''4.2 Aggregation
+                    of Means''.'
                   example:
                     partner:
                       date_of_birth: '1992-07-22'

--- a/swagger/v7/swagger.yaml
+++ b/swagger/v7/swagger.yaml
@@ -262,8 +262,9 @@ components:
               can be positive for a refund
             example: -5.24
           net_employment_income:
-            "$ref": "#/components/schemas/currency"
             description: Deprecated field not used in calculation
+            deprecated: true
+            "$ref": "#/components/schemas/currency"
     NonPropertyAsset:
       type: object
       additionalProperties: false
@@ -423,6 +424,7 @@ components:
             of 'partner' is described in Lord Chancellor's Certificated Guidance '3.1
             Individual and partner' and LC's Controlled Guidance '4.2 Aggregation
             of Means'
+          deprecated: true
         receives_qualifying_benefit:
           type: boolean
           example: false

--- a/swagger/v7/swagger.yaml
+++ b/swagger/v7/swagger.yaml
@@ -418,7 +418,11 @@ components:
         has_partner_opponent:
           type: boolean
           example: false
-          description: Applicant has partner opponent (unused in calculation)
+          description: Deprecated - not used in the calculation. A partner that is
+            an opponent in the case should *not* be included in the request. Definition
+            of 'partner' is described in Lord Chancellor's Certificated Guidance '3.1
+            Individual and partner' and LC's Controlled Guidance '4.2 Aggregation
+            of Means'
         receives_qualifying_benefit:
           type: boolean
           example: false
@@ -1867,7 +1871,10 @@ paths:
                   type: object
                   required:
                   - partner
-                  description: Full information about an applicant's partner
+                  description: Partner of the applicant's financial and personal info.
+                    Definition of 'partner' is described in Lord Chancellor's Certificated
+                    Guidance '3.1 Individual and partner' and LC's Controlled Guidance
+                    '4.2 Aggregation of Means'
                   example:
                     partner:
                       date_of_birth: '1992-07-22'
@@ -1924,7 +1931,7 @@ paths:
                   properties:
                     partner:
                       type: object
-                      description: The partner of the applicant
+                      description: Partner's personal info
                       required:
                       - date_of_birth
                       additionalProperties: false
@@ -1933,7 +1940,7 @@ paths:
                           type: string
                           format: date
                           example: '1992-07-22'
-                          description: Applicant's partner's date of birth
+                          description: Partner's date of birth
                         employed:
                           type: boolean
                           description: Deprecated - employment is determined by presence


### PR DESCRIPTION
Starting to implement [ideas for how we should document the API](https://dsdmoj.atlassian.net/wiki/spaces/EPT/pages/4468244596/API+documentation)

I can see this is the start of a fair amount of duplication of descriptions across these two files:

* spec/requests/swagger_docs/v6/full_assessment_spec.rb
* spec/requests/swagger_docs/v7/full_assessment_spec.rb

So if there's a better way to do this, do let me know.

No Jira ticket

---

## Checklist

Before you ask people to review this PR:

- Diff - review it, ensuring it contains only expected changes
- Whitespace changes - avoid if possible, because they make diffs harder to read and conflicts more likely
- Changelog - add a line, if it meets the criteria
- Commit messages - say *why* the change was made
- PR description - summarizes *what* changed and *why*, with a JIRA ticket ID
- Tests pass - on CircleCI
- Conflicts - resolve if Github reports them. e.g. with `git rebase main`
