### PR TITLE
Lep 189 reduce parameter logging

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -70,6 +70,8 @@ gem "govuk_notify_rails", "~> 2.2.0"
 # needed for diffing in re-runner tool
 gem "hashdiff"
 
+gem "lograge"
+
 group :development, :test do
   gem "awesome_print"
   gem "bullet"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -265,6 +265,11 @@ GEM
     listen (3.8.0)
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
+    lograge (0.13.0)
+      actionpack (>= 4)
+      activesupport (>= 4)
+      railties (>= 4)
+      request_store (~> 1.0)
     loofah (2.21.3)
       crass (~> 1.0.2)
       nokogiri (>= 1.12.0)
@@ -376,6 +381,8 @@ GEM
       declarative (< 0.1.0)
       trailblazer-option (>= 0.1.1, < 0.2.0)
       uber (< 0.2.0)
+    request_store (1.5.1)
+      rack (>= 1.4)
     retriable (3.1.2)
     rexml (3.2.6)
     roo (2.10.0)
@@ -542,6 +549,7 @@ DEPENDENCIES
   hashdiff
   json-schema (~> 3.0.0)
   listen (>= 3.0.5, < 3.9)
+  lograge
   nesty
   net-imap
   net-pop

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -40,9 +40,12 @@ Rails.application.configure do
   # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
   # config.force_ssl = true
 
-  # Use the lowest log level to ensure availability of diagnostic information
-  # when problems arise.
-  config.log_level = :debug
+  # Include generic and useful information about system operation, but avoid logging too much
+  # information to avoid inadvertent exposure of personally identifiable information (PII).
+  config.log_level = :info
+
+  # enable lograge in production builds so that parameters are not logged into MOJ wide system logs
+  config.lograge.enabled = true
 
   # Prepend all log lines with the following tags.
   config.log_tags = [:request_id]


### PR DESCRIPTION
https://dsdmoj.atlassian.net/browse/LEP-189

Use lograge to eliminate parameter logging in production - we are using the Rails hook to do our own logging, so redacting everything at the start (ala CCQ) wasn't a good fit for this project. Using lograge disables the parameter logging without upsetting our own logging code