### PR TITLE
Fix e2e tests to use OIDC for ECR auth

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -56,6 +56,8 @@ executors:
           POSTGRES_USER: postgres
           POSTGRES_DB: ccq_test
       - image: ${ECR_ENDPOINT}:${CIRCLE_SHA1}
+        aws_auth:
+          oidc_role_arn: $ECR_ROLE_TO_ASSUME
         environment:
           - RAILS_ENV: production
           - LEGAL_FRAMEWORK_API_HOST: https://legal-framework-api-staging.cloud-platform.service.justice.gov.uk


### PR DESCRIPTION
Use OIDC to get the image, now that the AWS Access Key env vars are deleted

<!--Ticket-->
Related to [LEP-202](https://dsdmoj.atlassian.net/browse/LEP-202)

<!-- Describe *what* you did and *why* -->

---

## Checklist

Before you ask people to review this PR:

- Diff - review it, ensuring it contains only expected changes
- Whitespace changes - avoid if possible, because they make diffs harder to read and conflicts more likely
- Changelog - add a line, if it meets the criteria
- Commit messages - say *why* the change was made
- PR description - summarizes *what* changed and *why*, with a JIRA ticket ID
- Tests pass - on CircleCI
- Conflicts - resolve if Github reports them. e.g. with `git rebase main`


[LEP-202]: https://dsdmoj.atlassian.net/browse/LEP-202?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ