### PR TITLE
Fix undercover config in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -226,7 +226,7 @@ jobs:
       - run:
           name: Check coverage with undercover
           command: |
-            bundle exec undercover -l coverage/lcov.info
+            bundle exec undercover -c origin/main -l coverage/lcov.info
       - store_test_results:
           path: /tmp/test-results/rspec
       - store_artifacts:


### PR DESCRIPTION
No Ticket

It looks like the 'undercover' tool isn't warning us when our tests don't have enough coverage. This is an attempt to fix that by adding a base branch to the Circle CI undercover command