### PR TITLE
Fix bundle install so that it fails if Gemfile.lock is out of step

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -120,7 +120,10 @@ references:
       name: Install ruby gems
       command: |
         sudo gem update --system
-        bundle install --without development --path=vendor/bundle --jobs=4 && bundle clean
+        bundle config set --local frozen 'true'
+        bundle config set --local path 'vendor/bundle'
+        bundle config set --local without 'development'
+        bundle install --jobs=4 && bundle clean
 
   save_gems_cache: &save_gems_cache
     save_cache:

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -578,4 +578,4 @@ RUBY VERSION
    ruby 3.2.2p53
 
 BUNDLED WITH
-   2.4.6
+   2.4.18


### PR DESCRIPTION
No Ticket

'bundle install' in CI would pass even if Gemfile and Gemfile.lock are out of step. This adds the 'frozen' flag to the bundle install command so that this cannot happen in the future