### PR TITLE
Add guard bundler to improve guard experience

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -96,6 +96,7 @@ end
 
 group :development do
   gem "guard"
+  gem "guard-bundler"
   gem "guard-cucumber"
   gem "guard-rspec"
   gem "guard-rubocop"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -235,6 +235,10 @@ GEM
       pry (>= 0.13.0)
       shellany (~> 0.0)
       thor (>= 0.18.1)
+    guard-bundler (3.0.1)
+      bundler (>= 2.1, < 3)
+      guard (~> 2.2)
+      guard-compat (~> 1.1)
     guard-compat (1.2.1)
     guard-cucumber (3.0.0)
       cucumber (>= 3.1)
@@ -542,6 +546,7 @@ DEPENDENCIES
   google_drive (>= 3.0.7)
   govuk_notify_rails (~> 2.2.0)
   guard
+  guard-bundler
   guard-cucumber
   guard-rspec
   guard-rubocop

--- a/Guardfile
+++ b/Guardfile
@@ -78,3 +78,15 @@ guard :shell, swagger_options do
     `NOCOVERAGE=1 bundle exec rake rswag:specs:swaggerize`
   end
 end
+
+guard :bundler do
+  require "guard/bundler"
+  require "guard/bundler/verify"
+  helper = Guard::Bundler::Verify.new
+
+  files = %w[Gemfile]
+  files += Dir["*.gemspec"] if files.any? { |f| helper.uses_gemspec?(f) }
+
+  # Assume files are symlinked from somewhere
+  files.each { |file| watch(helper.real_path(file)) }
+end


### PR DESCRIPTION
No Ticket

Add guard bundler so that when gems are updated, guard understands and reloads the bundle