### PR TITLE
LEP-305 Fix Swagger web page displaying the description/example for several fields

### DIFF
--- a/app/lib/swagger_docs.rb
+++ b/app/lib/swagger_docs.rb
@@ -280,27 +280,26 @@ class SwaggerDocs
                   example: "1992-07-22",
                 },
                 gross: {
-                  "$ref" => SCHEMA_COMPONENTS[:currency],
+                  oneOf: [{ "$ref" => SCHEMA_COMPONENTS[:currency] }], # "oneOf" hack - without it the Swagger web page doesn't display the description and other properties at this level
                   description: "Gross payment income received",
                   example: "101.01",
                 },
                 benefits_in_kind: {
-                  "$ref" => SCHEMA_COMPONENTS[:positive_currency],
+                  oneOf: [{ "$ref" => SCHEMA_COMPONENTS[:positive_currency] }], # "oneOf" hack
                   description: "Benefit in kind amount received",
                 },
                 tax: {
-                  "$ref" => SCHEMA_COMPONENTS[:currency],
+                  oneOf: [{ "$ref" => SCHEMA_COMPONENTS[:currency] }], # "oneOf" hack
                   description: "Amount of tax paid - normally negative, but can be positive for a refund",
                   example: -10.01,
                 },
                 national_insurance: {
-                  "$ref" => SCHEMA_COMPONENTS[:currency],
+                  oneOf: [{ "$ref" => SCHEMA_COMPONENTS[:currency] }], # "oneOf" hack
                   description: "Amount of national insurance paid - normally negative, but can be positive for a refund",
                   example: -5.24,
                 },
                 net_employment_income: {
-                  "$ref" => SCHEMA_COMPONENTS[:currency],
-                  # NB when using a $ref, the 'description' and 'deprecated' don't get displayed in the swagger web page - they are only visible to clients in the raw swagger.yaml
+                  oneOf: [{ "$ref" => SCHEMA_COMPONENTS[:currency] }], # "oneOf" hack
                   description: "Deprecated field not used in calculation",
                   deprecated: true,
                 },
@@ -622,7 +621,7 @@ class SwaggerDocs
                 },
               },
               assets_value: {
-                "$ref" => SCHEMA_COMPONENTS[:currency],
+                oneOf: [{ "$ref" => SCHEMA_COMPONENTS[:currency] }], # "oneOf" hack
                 description: "Dependant's total assets value",
               },
             },
@@ -680,7 +679,7 @@ class SwaggerDocs
                         example: "1992-07-28",
                       },
                       amount: {
-                        "$ref" => SCHEMA_COMPONENTS[:positive_currency],
+                        oneOf: [{ "$ref" => SCHEMA_COMPONENTS[:positive_currency] }], # "oneOf" hack
                         description: "Amount of payment received",
                       },
                       client_id: {
@@ -723,11 +722,11 @@ class SwaggerDocs
             required: %i[value outstanding_mortgage percentage_owned shared_with_housing_assoc],
             properties: {
               value: {
-                "$ref" => SCHEMA_COMPONENTS[:currency],
+                oneOf: [{ "$ref" => SCHEMA_COMPONENTS[:currency] }], # "oneOf" hack
                 description: "Financial value of the property",
               },
               outstanding_mortgage: {
-                "$ref" => SCHEMA_COMPONENTS[:currency],
+                oneOf: [{ "$ref" => SCHEMA_COMPONENTS[:currency] }], # "oneOf" hack
                 description: "Amount outstanding on all mortgages against this property",
               },
               percentage_owned: {
@@ -896,7 +895,7 @@ class SwaggerDocs
                       example: "1992-07-29",
                     },
                     amount: {
-                      "$ref" => SCHEMA_COMPONENTS[:currency],
+                      oneOf: [{ "$ref" => SCHEMA_COMPONENTS[:currency] }], # "oneOf" hack
                       description: "Amount of payment received",
                     },
                     flags: {
@@ -919,11 +918,11 @@ class SwaggerDocs
             required: %i[value date_of_purchase],
             properties: {
               value: {
-                "$ref" => SCHEMA_COMPONENTS[:positive_currency],
+                oneOf: [{ "$ref" => SCHEMA_COMPONENTS[:positive_currency] }], # "oneOf" hack
                 description: "Financial value of the vehicle",
               },
               loan_amount_outstanding: {
-                "$ref" => SCHEMA_COMPONENTS[:currency],
+                oneOf: [{ "$ref" => SCHEMA_COMPONENTS[:currency] }], # "oneOf" hack
                 description: "Amount remaining, if any, of a loan used to purchase the vehicle",
               },
               date_of_purchase: {

--- a/swagger/v6/swagger.yaml
+++ b/swagger/v6/swagger.yaml
@@ -245,24 +245,29 @@ components:
             format: date
             example: '1992-07-22'
           gross:
-            "$ref": "#/components/schemas/currency"
+            oneOf:
+            - "$ref": "#/components/schemas/currency"
             description: Gross payment income received
             example: '101.01'
           benefits_in_kind:
-            "$ref": "#/components/schemas/positive_currency"
+            oneOf:
+            - "$ref": "#/components/schemas/positive_currency"
             description: Benefit in kind amount received
           tax:
-            "$ref": "#/components/schemas/currency"
+            oneOf:
+            - "$ref": "#/components/schemas/currency"
             description: Amount of tax paid - normally negative, but can be positive
               for a refund
             example: -10.01
           national_insurance:
-            "$ref": "#/components/schemas/currency"
+            oneOf:
+            - "$ref": "#/components/schemas/currency"
             description: Amount of national insurance paid - normally negative, but
               can be positive for a refund
             example: -5.24
           net_employment_income:
-            "$ref": "#/components/schemas/currency"
+            oneOf:
+            - "$ref": "#/components/schemas/currency"
             description: Deprecated field not used in calculation
             deprecated: true
     NonPropertyAsset:
@@ -631,7 +636,8 @@ components:
             amount:
               "$ref": "#/components/schemas/currency"
         assets_value:
-          "$ref": "#/components/schemas/currency"
+          oneOf:
+          - "$ref": "#/components/schemas/currency"
           description: Dependant's total assets value
       additionalProperties: false
     IrregularIncomePayments:
@@ -705,7 +711,8 @@ components:
                   format: date
                   example: '1992-07-28'
                 amount:
-                  "$ref": "#/components/schemas/positive_currency"
+                  oneOf:
+                  - "$ref": "#/components/schemas/positive_currency"
                   description: Amount of payment received
                 client_id:
                   type: string
@@ -795,10 +802,12 @@ components:
       - shared_with_housing_assoc
       properties:
         value:
-          "$ref": "#/components/schemas/currency"
+          oneOf:
+          - "$ref": "#/components/schemas/currency"
           description: Financial value of the property
         outstanding_mortgage:
-          "$ref": "#/components/schemas/currency"
+          oneOf:
+          - "$ref": "#/components/schemas/currency"
           description: Amount outstanding on all mortgages against this property
         percentage_owned:
           type: number
@@ -988,7 +997,8 @@ components:
                 format: date
                 example: '1992-07-29'
               amount:
-                "$ref": "#/components/schemas/currency"
+                oneOf:
+                - "$ref": "#/components/schemas/currency"
                 description: Amount of payment received
               flags:
                 type: object
@@ -1007,10 +1017,12 @@ components:
       - date_of_purchase
       properties:
         value:
-          "$ref": "#/components/schemas/positive_currency"
+          oneOf:
+          - "$ref": "#/components/schemas/positive_currency"
           description: Financial value of the vehicle
         loan_amount_outstanding:
-          "$ref": "#/components/schemas/currency"
+          oneOf:
+          - "$ref": "#/components/schemas/currency"
           description: Amount remaining, if any, of a loan used to purchase the vehicle
         date_of_purchase:
           type: string

--- a/swagger/v7/swagger.yaml
+++ b/swagger/v7/swagger.yaml
@@ -245,24 +245,29 @@ components:
             format: date
             example: '1992-07-22'
           gross:
-            "$ref": "#/components/schemas/currency"
+            oneOf:
+            - "$ref": "#/components/schemas/currency"
             description: Gross payment income received
             example: '101.01'
           benefits_in_kind:
-            "$ref": "#/components/schemas/positive_currency"
+            oneOf:
+            - "$ref": "#/components/schemas/positive_currency"
             description: Benefit in kind amount received
           tax:
-            "$ref": "#/components/schemas/currency"
+            oneOf:
+            - "$ref": "#/components/schemas/currency"
             description: Amount of tax paid - normally negative, but can be positive
               for a refund
             example: -10.01
           national_insurance:
-            "$ref": "#/components/schemas/currency"
+            oneOf:
+            - "$ref": "#/components/schemas/currency"
             description: Amount of national insurance paid - normally negative, but
               can be positive for a refund
             example: -5.24
           net_employment_income:
-            "$ref": "#/components/schemas/currency"
+            oneOf:
+            - "$ref": "#/components/schemas/currency"
             description: Deprecated field not used in calculation
             deprecated: true
     NonPropertyAsset:
@@ -631,7 +636,8 @@ components:
             amount:
               "$ref": "#/components/schemas/currency"
         assets_value:
-          "$ref": "#/components/schemas/currency"
+          oneOf:
+          - "$ref": "#/components/schemas/currency"
           description: Dependant's total assets value
       additionalProperties: false
     IrregularIncomePayments:
@@ -705,7 +711,8 @@ components:
                   format: date
                   example: '1992-07-28'
                 amount:
-                  "$ref": "#/components/schemas/positive_currency"
+                  oneOf:
+                  - "$ref": "#/components/schemas/positive_currency"
                   description: Amount of payment received
                 client_id:
                   type: string
@@ -795,10 +802,12 @@ components:
       - shared_with_housing_assoc
       properties:
         value:
-          "$ref": "#/components/schemas/currency"
+          oneOf:
+          - "$ref": "#/components/schemas/currency"
           description: Financial value of the property
         outstanding_mortgage:
-          "$ref": "#/components/schemas/currency"
+          oneOf:
+          - "$ref": "#/components/schemas/currency"
           description: Amount outstanding on all mortgages against this property
         percentage_owned:
           type: number
@@ -988,7 +997,8 @@ components:
                 format: date
                 example: '1992-07-29'
               amount:
-                "$ref": "#/components/schemas/currency"
+                oneOf:
+                - "$ref": "#/components/schemas/currency"
                 description: Amount of payment received
               flags:
                 type: object
@@ -1007,10 +1017,12 @@ components:
       - date_of_purchase
       properties:
         value:
-          "$ref": "#/components/schemas/positive_currency"
+          oneOf:
+          - "$ref": "#/components/schemas/positive_currency"
           description: Financial value of the vehicle
         loan_amount_outstanding:
-          "$ref": "#/components/schemas/currency"
+          oneOf:
+          - "$ref": "#/components/schemas/currency"
           description: Amount remaining, if any, of a loan used to purchase the vehicle
         date_of_purchase:
           type: string


### PR DESCRIPTION
When using "$ref" in the schema, there is a bug in the Swagger web page that hides sibling properties, such as the field's description.

This PR fixes it by introducing the "oneOf" extra level of abstraction, as discovered by @starswan [here](https://github.com/ministryofjustice/cfe-civil/pull/242#discussion_r1284332230). It's a bit messy, but preferable I think to display the descriptions.

Before:
<img width="1117" alt="Screenshot 2023-08-04 at 17 02 06" src="https://github.com/ministryofjustice/cfe-civil/assets/307612/5ebc2ac8-3145-45eb-906b-d1532a4bd859">

After:
<img width="1333" alt="Screenshot 2023-08-04 at 17 08 46" src="https://github.com/ministryofjustice/cfe-civil/assets/307612/9e9a91d1-a96e-44ab-8230-fa5af8097eec">

Jira ticket: [LEP-305](https://dsdmoj.atlassian.net/browse/LEP-305)

---

## Checklist

Before you ask people to review this PR:

- Diff - review it, ensuring it contains only expected changes
- Whitespace changes - avoid if possible, because they make diffs harder to read and conflicts more likely
- Changelog - add a line, if it meets the criteria
- Commit messages - say *why* the change was made
- PR description - summarizes *what* changed and *why*, with a JIRA ticket ID
- Tests pass - on CircleCI
- Conflicts - resolve if Github reports them. e.g. with `git rebase main`


[LEP-305]: https://dsdmoj.atlassian.net/browse/LEP-305?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ