### PR TITLE
LEP-308 check client_reference_id before redacting

### DIFF
--- a/app/models/request_log.rb
+++ b/app/models/request_log.rb
@@ -1,3 +1,4 @@
 class RequestLog < RequestLogBase
   validates :request, :response, :user_agent, presence: true
+  scope :with_client_reference, -> { where("request -> 'assessment' ->> 'client_reference_id' IS NOT NULL") }
 end

--- a/app/services/redact_service.rb
+++ b/app/services/redact_service.rb
@@ -9,7 +9,7 @@ class RedactService
     end
 
     def redact_old_client_refs
-      RequestLog.where("created_at < ?", 14.days.ago.to_date).find_each do |li|
+      RequestLog.with_client_reference.where("created_at < ?", 14.days.ago.to_date).find_each do |li|
         li.update!(request: redact_client_ref(li.request.deep_symbolize_keys))
       end
     end

--- a/spec/models/request_log_spec.rb
+++ b/spec/models/request_log_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe RequestLog do
   context "scopes" do
     describe ".with_client_reference" do
       before do
-        create(:request_log)
+        create(:request_log, request: { assessment: { client_reference_id: nil } })
         create(:request_log, request: { assessment: { client_reference_id: "client_reference_id" } })
         create(:request_log, request: { applicant: {} })
       end

--- a/spec/models/request_log_spec.rb
+++ b/spec/models/request_log_spec.rb
@@ -6,6 +6,7 @@ RSpec.describe RequestLog do
       before do
         create(:request_log)
         create(:request_log, request: { assessment: { client_reference_id: "client_reference_id" } })
+        create(:request_log, request: { applicant: {} })
       end
 
       it "return request_logs filtered by client_reference_id" do

--- a/spec/models/request_log_spec.rb
+++ b/spec/models/request_log_spec.rb
@@ -1,0 +1,16 @@
+require "rails_helper"
+
+RSpec.describe RequestLog do
+  context "scopes" do
+    describe ".with_client_reference" do
+      before do
+        create(:request_log)
+        create(:request_log, request: { assessment: { client_reference_id: "client_reference_id" } })
+      end
+
+      it "return request_logs filtered by client_reference_id" do
+        expect(described_class.with_client_reference.count).to eq 1
+      end
+    end
+  end
+end

--- a/spec/requests/v6/assessments_controller/simple_spec.rb
+++ b/spec/requests/v6/assessments_controller/simple_spec.rb
@@ -1799,7 +1799,7 @@ module V6
               RedactService.redact_old_client_refs
             end
 
-            context "when present" do
+            context "when assessment.client_reference_id is present" do
               let(:params) { { assessment: { client_reference_id: client_ref } } }
 
               it "redacts the client reference" do
@@ -1807,8 +1807,10 @@ module V6
               end
             end
 
-            context "when not present" do
-              it "redacts the client reference" do
+            context "when assessment.client_reference_id not present" do
+              let(:params) { { assessment: {} } }
+
+              it "doesn't redact the client reference" do
                 expect(log_record.request["assessment"]["client_reference_id"]).to eq(nil)
               end
             end

--- a/spec/requests/v6/assessments_controller/simple_spec.rb
+++ b/spec/requests/v6/assessments_controller/simple_spec.rb
@@ -15,6 +15,7 @@ module V6
       let(:month3) { current_date.beginning_of_month - 1.month }
       let(:dob) { "2001-02-02" }
       let(:redacted_message) { CFEConstants::REDACTED_MESSAGE }
+      let(:client_ref) { "3000-01-01" }
       let(:default_params) do
         {
           assessment: submission_date_params,
@@ -1792,16 +1793,29 @@ module V6
             expect(log_record.response["timestamp"]).to eq("2022-04-20")
           end
 
-          it "redacts the client reference" do
-            RequestLog.update_all(created_at: 3.weeks.ago)
-            RedactService.redact_old_client_refs
+          context "client_reference_id" do
+            before do
+              RequestLog.update_all(created_at: 3.weeks.ago)
+              RedactService.redact_old_client_refs
+            end
 
-            expect(log_record.request["assessment"]["client_reference_id"]).to eq(redacted_message)
+            context "when present" do
+              let(:params) { { assessment: { client_reference_id: client_ref } } }
+
+              it "redacts the client reference" do
+                expect(log_record.request["assessment"]["client_reference_id"]).to eq(redacted_message)
+              end
+            end
+
+            context "when not present" do
+              it "redacts the client reference" do
+                expect(log_record.request["assessment"]["client_reference_id"]).to eq(nil)
+              end
+            end
           end
         end
 
         context "with unsuccessful submission" do
-          let(:client_ref) { "3000-01-01" }
           let(:params) { { assessment: { client_reference_id: client_ref } } }
 
           it "returns http error" do


### PR DESCRIPTION
<!--Ticket-->
[LEP-308](https://dsdmoj.atlassian.net/browse/LEP-308)

`RedactService.redact_old_client_refs` is throwing error while redacting  assessment object with missing `client_reference_id` (as `client_reference_id` is optional attribute in request)

Solution: 
Filter `RequestLog` and then apply redaction

Slack: https://mojdt.slack.com/archives/C04T88Q1B61/p1691374001872429

[LEP-308]: https://dsdmoj.atlassian.net/browse/LEP-308?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ