### PR TITLE
LEP-305 Fix for swagger example being made invalid

### DIFF
--- a/app/lib/swagger_docs.rb
+++ b/app/lib/swagger_docs.rb
@@ -100,6 +100,7 @@ class SwaggerDocs
                 pattern: "^[-+]?\\d+(\\.\\d{1,2})?$",
               },
             ],
+            example: 70.25,
           },
           numeric_currency: {
             description: "Currency as number",
@@ -126,6 +127,7 @@ class SwaggerDocs
                 pattern: "^[+]?\\d+(\\.\\d{1,2})?$",
               },
             ],
+            example: 60.99,
           },
           ProceedingTypeResult: {
             type: :object,
@@ -282,11 +284,12 @@ class SwaggerDocs
                 gross: {
                   oneOf: [{ "$ref" => SCHEMA_COMPONENTS[:currency] }], # "oneOf" hack - without it the Swagger web page doesn't display the description and other properties at this level
                   description: "Gross payment income received",
-                  example: "101.01",
+                  example: 101.01,
                 },
                 benefits_in_kind: {
                   oneOf: [{ "$ref" => SCHEMA_COMPONENTS[:positive_currency] }], # "oneOf" hack
                   description: "Benefit in kind amount received",
+                  example: 10.50,
                 },
                 tax: {
                   oneOf: [{ "$ref" => SCHEMA_COMPONENTS[:currency] }], # "oneOf" hack
@@ -607,6 +610,7 @@ class SwaggerDocs
                   { "$ref" => SCHEMA_COMPONENTS[:numeric_currency] },
                   { "$ref" => SCHEMA_COMPONENTS[:string_currency] },
                 ],
+                example: 0,
               },
               income: {
                 type: :object,

--- a/swagger/v6/swagger.yaml
+++ b/swagger/v6/swagger.yaml
@@ -23,6 +23,7 @@ components:
         multipleOf: 0.01
       - type: string
         pattern: "^[-+]?\\d+(\\.\\d{1,2})?$"
+      example: 70.25
     numeric_currency:
       description: Currency as number
       type: number
@@ -41,6 +42,7 @@ components:
         multipleOf: 0.01
       - type: string
         pattern: "^[+]?\\d+(\\.\\d{1,2})?$"
+      example: 60.99
     ProceedingTypeResult:
       type: object
       required:
@@ -248,11 +250,12 @@ components:
             oneOf:
             - "$ref": "#/components/schemas/currency"
             description: Gross payment income received
-            example: '101.01'
+            example: 101.01
           benefits_in_kind:
             oneOf:
             - "$ref": "#/components/schemas/positive_currency"
             description: Benefit in kind amount received
+            example: 10.5
           tax:
             oneOf:
             - "$ref": "#/components/schemas/currency"
@@ -619,6 +622,7 @@ components:
           oneOf:
           - "$ref": "#/components/schemas/numeric_currency"
           - "$ref": "#/components/schemas/string_currency"
+          example: 0
         income:
           type: object
           required:

--- a/swagger/v7/swagger.yaml
+++ b/swagger/v7/swagger.yaml
@@ -23,6 +23,7 @@ components:
         multipleOf: 0.01
       - type: string
         pattern: "^[-+]?\\d+(\\.\\d{1,2})?$"
+      example: 70.25
     numeric_currency:
       description: Currency as number
       type: number
@@ -41,6 +42,7 @@ components:
         multipleOf: 0.01
       - type: string
         pattern: "^[+]?\\d+(\\.\\d{1,2})?$"
+      example: 60.99
     ProceedingTypeResult:
       type: object
       required:
@@ -248,11 +250,12 @@ components:
             oneOf:
             - "$ref": "#/components/schemas/currency"
             description: Gross payment income received
-            example: '101.01'
+            example: 101.01
           benefits_in_kind:
             oneOf:
             - "$ref": "#/components/schemas/positive_currency"
             description: Benefit in kind amount received
+            example: 10.5
           tax:
             oneOf:
             - "$ref": "#/components/schemas/currency"
@@ -619,6 +622,7 @@ components:
           oneOf:
           - "$ref": "#/components/schemas/numeric_currency"
           - "$ref": "#/components/schemas/string_currency"
+          example: 0
         income:
           type: object
           required:


### PR DESCRIPTION
<!--Ticket-->
[LEP-305](https://dsdmoj.atlassian.net/browse/LEP-305)

The [previous PR](https://github.com/ministryofjustice/cfe-civil/pull/265) broke the example JSON request, that gets displayed in the Swagger web page:
![Screenshot 2023-08-11 at 12 46 09](https://github.com/ministryofjustice/cfe-civil/assets/307612/b9f3bb43-4471-4478-9157-3616343ecb50)

Submitting it gave validation errors - the currency values were coming out as `"string"`.
e.g. `The property '#/dependants/0/assets_value' of type string did not match any of the required schemas. The schema specific errors were:\n\n    - oneOf #0:\n        - The property '#/dependants/0/assets_value' of type string did not match the following type: number\n    - oneOf #1:\n        - The property '#/dependants/0/assets_value' value \"string\" did not match the regex '^[-+]?\\d+(\\.\\d{1,2})?$'"`

This PR fixes those example values:
![Screenshot 2023-08-11 at 12 48 32](https://github.com/ministryofjustice/cfe-civil/assets/307612/cd4519cb-ff9c-4299-bece-5889dc57582c)

and it now submits ok.

---

## Checklist

Before you ask people to review this PR:

- Diff - review it, ensuring it contains only expected changes
- Whitespace changes - avoid if possible, because they make diffs harder to read and conflicts more likely
- Changelog - add a line, if it meets the criteria
- Commit messages - say *why* the change was made
- PR description - summarizes *what* changed and *why*, with a JIRA ticket ID
- Tests pass - on CircleCI
- Conflicts - resolve if Github reports them. e.g. with `git rebase main`


[LEP-305]: https://dsdmoj.atlassian.net/browse/LEP-305?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ