### PR TITLE
LEP-271 - remove maintenance_out outputs from disposable_income_summary

### DIFF
--- a/app/lib/person_disposable_income_subtotals.rb
+++ b/app/lib/person_disposable_income_subtotals.rb
@@ -76,4 +76,16 @@ class PersonDisposableIncomeSubtotals
   def net_housing_costs
     @outgoings.housing_costs.net_housing_costs
   end
+
+  def maintenance_out_bank
+    @outgoings.maintenance_out_bank
+  end
+
+  def maintenance_out_cash
+    @disposable.maintenance_out_cash
+  end
+
+  def maintenance_out_all_sources
+    maintenance_out_bank + maintenance_out_cash + @regular.maintenance_out_regular
+  end
 end

--- a/app/services/collators/disposable_income_collator.rb
+++ b/app/services/collators/disposable_income_collator.rb
@@ -1,9 +1,9 @@
 module Collators
   class DisposableIncomeCollator
-    Attrs = Data.define(:attrs, :monthly_cash_transactions_total, :rent_or_mortgage_cash, :legal_aid_cash)
-    Result = Data.define(:rent_or_mortgage_cash, :legal_aid_cash) do
+    Attrs = Data.define(:attrs, :monthly_cash_transactions_total, :rent_or_mortgage_cash, :legal_aid_cash, :maintenance_out_cash)
+    Result = Data.define(:rent_or_mortgage_cash, :legal_aid_cash, :maintenance_out_cash) do
       def self.blank
-        new(rent_or_mortgage_cash: 0, legal_aid_cash: 0)
+        new(rent_or_mortgage_cash: 0, legal_aid_cash: 0, maintenance_out_cash: 0)
       end
     end
 
@@ -29,7 +29,7 @@ module Collators
         total_disposable_income: disposable_income(attrs.monthly_cash_transactions_total),
       )
 
-      Result.new(rent_or_mortgage_cash: attrs.rent_or_mortgage_cash, legal_aid_cash: attrs.legal_aid_cash)
+      Result.new(rent_or_mortgage_cash: attrs.rent_or_mortgage_cash, legal_aid_cash: attrs.legal_aid_cash, maintenance_out_cash: attrs.maintenance_out_cash)
     end
 
   private
@@ -47,6 +47,7 @@ module Collators
 
       Attrs.new(attrs:,
                 legal_aid_cash: legal_aid_cash_amount,
+                maintenance_out_cash: maintenance_out_cash_amount,
                 rent_or_mortgage_cash: monthly_cash_by_category(:rent_or_mortgage),
                 monthly_cash_transactions_total: maintenance_out_cash_amount + @outgoings.child_care.cash + legal_aid_cash_amount)
     end
@@ -69,7 +70,7 @@ module Collators
 
     def monthly_bank_transactions_total
       @outgoings.child_care.bank +
-        @disposable_income_summary.maintenance_out_bank +
+        @outgoings.maintenance_out_bank +
         @outgoings.legal_aid_bank
     end
 

--- a/app/services/collators/disposable_income_collator.rb
+++ b/app/services/collators/disposable_income_collator.rb
@@ -1,6 +1,6 @@
 module Collators
   class DisposableIncomeCollator
-    Attrs = Data.define(:attrs, :monthly_cash_transactions_total, :rent_or_mortgage_cash, :legal_aid_cash, :maintenance_out_cash)
+    Attrs = Data.define(:monthly_cash_transactions_total, :rent_or_mortgage_cash, :legal_aid_cash, :maintenance_out_cash)
     Result = Data.define(:rent_or_mortgage_cash, :legal_aid_cash, :maintenance_out_cash) do
       def self.blank
         new(rent_or_mortgage_cash: 0, legal_aid_cash: 0, maintenance_out_cash: 0)
@@ -23,7 +23,6 @@ module Collators
 
     def call
       attrs = populate_attrs
-      @disposable_income_summary.update!(attrs.attrs)
       @disposable_income_summary.update!(
         total_outgoings_and_allowances: total_outgoings_and_allowances(attrs.monthly_cash_transactions_total),
         total_disposable_income: disposable_income(attrs.monthly_cash_transactions_total),
@@ -37,16 +36,9 @@ module Collators
     def populate_attrs
       maintenance_out_cash_amount = monthly_cash_by_category(:maintenance_out)
 
-      attrs = {
-        maintenance_out_bank: @disposable_income_summary.maintenance_out_bank,
-        maintenance_out_cash: maintenance_out_cash_amount,
-        maintenance_out_all_sources: @disposable_income_summary.maintenance_out_bank + maintenance_out_cash_amount,
-      }
-
       legal_aid_cash_amount = monthly_cash_by_category(:legal_aid)
 
-      Attrs.new(attrs:,
-                legal_aid_cash: legal_aid_cash_amount,
+      Attrs.new(legal_aid_cash: legal_aid_cash_amount,
                 maintenance_out_cash: maintenance_out_cash_amount,
                 rent_or_mortgage_cash: monthly_cash_by_category(:rent_or_mortgage),
                 monthly_cash_transactions_total: maintenance_out_cash_amount + @outgoings.child_care.cash + legal_aid_cash_amount)

--- a/app/services/collators/disposable_income_collator.rb
+++ b/app/services/collators/disposable_income_collator.rb
@@ -61,9 +61,11 @@ module Collators
     end
 
     def monthly_bank_transactions_total
-      @outgoings.child_care.bank +
-        @outgoings.maintenance_out_bank +
-        @outgoings.legal_aid_bank
+      [
+        @outgoings.child_care.bank,
+        @outgoings.maintenance_out_bank,
+        @outgoings.legal_aid_bank,
+      ].sum
     end
 
     def disposable_income(monthly_cash_transactions_total)

--- a/app/services/collators/outgoings_collator.rb
+++ b/app/services/collators/outgoings_collator.rb
@@ -21,8 +21,6 @@ module Collators
                                                                           submission_date:)
 
         maintenance_out_bank = Collators::MaintenanceCollator.call(disposable_income_summary.maintenance_outgoings)
-        # TODO: return this value instead of persisting it
-        disposable_income_summary.update!(maintenance_out_bank:)
 
         housing_costs = Collators::HousingCostsCollator.call(housing_cost_outgoings: disposable_income_summary.housing_cost_outgoings,
                                                              gross_income_summary:,

--- a/app/services/collators/outgoings_collator.rb
+++ b/app/services/collators/outgoings_collator.rb
@@ -1,11 +1,12 @@
 module Collators
   class OutgoingsCollator
-    Result = Data.define(:dependant_allowance, :child_care, :rent_or_mortgage_bank, :housing_costs, :legal_aid_bank) do
+    Result = Data.define(:dependant_allowance, :child_care, :rent_or_mortgage_bank, :housing_costs, :legal_aid_bank, :maintenance_out_bank) do
       def self.blank
         new(dependant_allowance: DependantsAllowanceCollator::Result.blank,
             child_care: ChildcareCollator::Result.blank,
             rent_or_mortgage_bank: 0,
             legal_aid_bank: 0,
+            maintenance_out_bank: 0,
             housing_costs: HousingCostsCollator::Result.blank)
       end
     end
@@ -35,7 +36,8 @@ module Collators
                    child_care:,
                    rent_or_mortgage_bank: housing_costs.gross_housing_costs_bank,
                    housing_costs:,
-                   legal_aid_bank:)
+                   legal_aid_bank:,
+                   maintenance_out_bank:)
       end
     end
   end

--- a/app/services/collators/regular_outgoings_collator.rb
+++ b/app/services/collators/regular_outgoings_collator.rb
@@ -11,10 +11,10 @@
 #
 module Collators
   class RegularOutgoingsCollator
-    Attrs = Data.define(:attrs, :child_care_regular, :rent_or_mortgage_regular, :legal_aid_regular)
-    Result = Data.define(:child_care_regular, :rent_or_mortgage_regular, :legal_aid_regular) do
+    Attrs = Data.define(:attrs, :child_care_regular, :rent_or_mortgage_regular, :legal_aid_regular, :maintenance_out_regular)
+    Result = Data.define(:child_care_regular, :rent_or_mortgage_regular, :legal_aid_regular, :maintenance_out_regular) do
       def self.blank
-        new(child_care_regular: 0, rent_or_mortgage_regular: 0, legal_aid_regular: 0)
+        new(child_care_regular: 0, rent_or_mortgage_regular: 0, legal_aid_regular: 0, maintenance_out_regular: 0)
       end
     end
 
@@ -24,7 +24,8 @@ module Collators
         disposable_income_summary.update!(attrs.attrs)
         Result.new(child_care_regular: attrs.child_care_regular,
                    rent_or_mortgage_regular: attrs.rent_or_mortgage_regular,
-                   legal_aid_regular: attrs.legal_aid_regular)
+                   legal_aid_regular: attrs.legal_aid_regular,
+                   maintenance_out_regular: attrs.maintenance_out_regular)
       end
 
     private
@@ -59,7 +60,8 @@ module Collators
 
         Attrs.new(attrs:, child_care_regular: childcare_monthly_amount,
                   rent_or_mortgage_regular: rent_or_mortgage_monthly_amount,
-                  legal_aid_regular: legal_aid_monthly_amount)
+                  legal_aid_regular: legal_aid_monthly_amount,
+                  maintenance_out_regular: maintenance_out_monthly_amount)
       end
 
       def regular_amount_for(gross_income_summary, category)

--- a/app/services/collators/regular_outgoings_collator.rb
+++ b/app/services/collators/regular_outgoings_collator.rb
@@ -32,13 +32,11 @@ module Collators
 
       def disposable_income_attributes(disposable_income_summary:, eligible_for_childcare:, gross_income_summary:)
         attrs = {
-          maintenance_out_all_sources: disposable_income_summary.maintenance_out_all_sources,
           total_outgoings_and_allowances: disposable_income_summary.total_outgoings_and_allowances,
           total_disposable_income: disposable_income_summary.total_disposable_income,
         }
 
         maintenance_out_monthly_amount = regular_amount_for(gross_income_summary, :maintenance_out)
-        attrs[:maintenance_out_all_sources] += maintenance_out_monthly_amount
 
         attrs[:total_outgoings_and_allowances] += maintenance_out_monthly_amount
         attrs[:total_disposable_income] -= maintenance_out_monthly_amount

--- a/app/services/decorators/v6/disposable_income_decorator.rb
+++ b/app/services/decorators/v6/disposable_income_decorator.rb
@@ -32,7 +32,7 @@ module Decorators
         {
           child_care: @disposable_income_subtotals.__send__("child_care_#{source}").to_f,
           rent_or_mortgage: @disposable_income_subtotals.__send__("rent_or_mortgage_#{source}").to_f,
-          maintenance_out: @summary.__send__("maintenance_out_#{source}").to_f,
+          maintenance_out: @disposable_income_subtotals.__send__("maintenance_out_#{source}").to_f,
           legal_aid: @disposable_income_subtotals.__send__("legal_aid_#{source}").to_f,
         }
       end

--- a/app/services/decorators/v6/disposable_income_result_decorator.rb
+++ b/app/services/decorators/v6/disposable_income_result_decorator.rb
@@ -27,7 +27,7 @@ module Decorators
           gross_housing_costs: @disposable_income_subtotals.gross_housing_costs.to_f,
           housing_benefit: @disposable_income_subtotals.housing_benefit.to_f,
           net_housing_costs: @disposable_income_subtotals.net_housing_costs.to_f,
-          maintenance_allowance: @summary.maintenance_out_all_sources.to_f,
+          maintenance_allowance: @disposable_income_subtotals.maintenance_out_all_sources.to_f,
           total_outgoings_and_allowances: @summary.total_outgoings_and_allowances.to_f,
           total_disposable_income: @summary.total_disposable_income.to_f,
           employment_income:,

--- a/db/migrate/20230815143445_remove_maintenance_out_columns_from_from_disposable_income_summary.rb
+++ b/db/migrate/20230815143445_remove_maintenance_out_columns_from_from_disposable_income_summary.rb
@@ -1,0 +1,9 @@
+class RemoveMaintenanceOutColumnsFromFromDisposableIncomeSummary < ActiveRecord::Migration[7.0]
+  def change
+    change_table :disposable_income_summaries, bulk: true do |t|
+      t.remove :maintenance_out_cash, type: :decimal, default: 0.0
+      t.remove :maintenance_out_bank, type: :decimal, default: 0.0
+      t.remove :maintenance_out_all_sources, type: :decimal, default: 0.0
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_08_13_082709) do
+ActiveRecord::Schema[7.0].define(version: 2023_08_15_143445) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -67,9 +67,6 @@ ActiveRecord::Schema[7.0].define(version: 2023_08_13_082709) do
     t.decimal "upper_threshold", default: "0.0", null: false
     t.string "assessment_result", default: "pending", null: false
     t.decimal "income_contribution", default: "0.0"
-    t.decimal "maintenance_out_all_sources", default: "0.0"
-    t.decimal "maintenance_out_bank", default: "0.0"
-    t.decimal "maintenance_out_cash", default: "0.0"
     t.string "type", default: "ApplicantDisposableIncomeSummary"
     t.decimal "combined_total_disposable_income"
     t.decimal "combined_total_outgoings_and_allowances"

--- a/spec/factories/disposable_income_summary_factory.rb
+++ b/spec/factories/disposable_income_summary_factory.rb
@@ -1,7 +1,6 @@
 FactoryBot.define do
   factory :disposable_income_summary do
     assessment
-    maintenance_out_bank { 0.0 }
     total_outgoings_and_allowances { 0.0 }
     total_disposable_income { 0.0 }
 

--- a/spec/services/collators/disposable_income_collator_spec.rb
+++ b/spec/services/collators/disposable_income_collator_spec.rb
@@ -41,7 +41,7 @@ module Collators
     end
 
     let(:total_outgoings) do
-      disposable_income_summary.maintenance_out_cash +
+      maintenance_out_cash +
         legal_aid_cash +
         child_care_bank +
         maintenance_out_bank +
@@ -55,6 +55,7 @@ module Collators
 
     # this comes from create :gross_income_summary, :with_all_records and is a random amount each time
     let(:legal_aid_cash) { Calculators::MonthlyCashTransactionAmountCalculator.call(assessment.applicant_gross_income_summary.cash_transactions(:debit, :legal_aid)) }
+    let(:maintenance_out_cash) { Calculators::MonthlyCashTransactionAmountCalculator.call(assessment.applicant_gross_income_summary.cash_transactions(:debit, :maintenance_out)) }
 
     before { create :gross_income_summary, :with_all_records, assessment: }
 
@@ -70,6 +71,7 @@ module Collators
                                                                                             over_16: dependant_allowance_over_16),
                                rent_or_mortgage_bank: 0,
                                legal_aid_bank:,
+                               maintenance_out_bank:,
                                housing_costs: Collators::HousingCostsCollator::Result.new(
                                  housing_benefit:,
                                  gross_housing_costs: gross_housing,

--- a/spec/services/collators/disposable_income_collator_spec.rb
+++ b/spec/services/collators/disposable_income_collator_spec.rb
@@ -33,7 +33,6 @@ module Collators
 
     let(:disposable_income_summary) do
       create(:disposable_income_summary,
-             maintenance_out_bank:,
              total_outgoings_and_allowances: 0.0,
              total_disposable_income: 0.0).tap do |summary|
         create :disposable_income_eligibility, disposable_income_summary: summary, proceeding_type_code: "DA001"
@@ -134,15 +133,15 @@ module Collators
         end
       end
 
-      context "all transactions" do
-        it "updates with totals for all categories based on bank and cash transactions" do
-          collator
-          disposable_income_summary.reload
-          maintenance_out_total = disposable_income_summary.maintenance_out_bank + disposable_income_summary.maintenance_out_cash
-
-          expect(disposable_income_summary.maintenance_out_all_sources).to eq maintenance_out_total
-        end
-      end
+      # context "all transactions" do
+      #   it "updates with totals for all categories based on bank and cash transactions" do
+      #     collator
+      #     disposable_income_summary.reload
+      #     maintenance_out_total = disposable_income_summary.maintenance_out_bank + disposable_income_summary.maintenance_out_cash
+      #
+      #     expect(disposable_income_summary.maintenance_out_all_sources).to eq maintenance_out_total
+      #   end
+      # end
     end
   end
 end

--- a/spec/services/collators/disposable_income_collator_spec.rb
+++ b/spec/services/collators/disposable_income_collator_spec.rb
@@ -132,16 +132,6 @@ module Collators
           end
         end
       end
-
-      # context "all transactions" do
-      #   it "updates with totals for all categories based on bank and cash transactions" do
-      #     collator
-      #     disposable_income_summary.reload
-      #     maintenance_out_total = disposable_income_summary.maintenance_out_bank + disposable_income_summary.maintenance_out_cash
-      #
-      #     expect(disposable_income_summary.maintenance_out_all_sources).to eq maintenance_out_total
-      #   end
-      # end
     end
   end
 end

--- a/spec/services/collators/regular_outgoings_collator_spec.rb
+++ b/spec/services/collators/regular_outgoings_collator_spec.rb
@@ -243,7 +243,7 @@ RSpec.describe Collators::RegularOutgoingsCollator do
         end
 
         it "increments #<category>_all_sources data to existing values" do
-          expect(collator).to have_attributes(legal_aid_regular: 2_000.00, maintenance_out_regular: 1_333.33)
+          expect(collator).to have_attributes(legal_aid_regular: 2_000.00, maintenance_out_regular: 1000.00)
         end
 
         it "increments #total_outgoings_and_allowances against existing value" do

--- a/spec/services/collators/regular_outgoings_collator_spec.rb
+++ b/spec/services/collators/regular_outgoings_collator_spec.rb
@@ -24,10 +24,6 @@ RSpec.describe Collators::RegularOutgoingsCollator do
     context "without monthly regular transactions" do
       it "does increments #<cagtegory>_all_sources data" do
         expect(collator).to have_attributes(legal_aid_regular: 0.0, maintenance_out_regular: 0.0)
-        # disposable_income_summary.reload
-        # expect(disposable_income_summary).to have_attributes(
-        #   maintenance_out_all_sources: 0.0,
-        # )
       end
 
       it "does not increment #total_outgoings_and_allowances" do
@@ -52,10 +48,6 @@ RSpec.describe Collators::RegularOutgoingsCollator do
 
       it "increments #<cagtegory>_all_sources data" do
         expect(collator).to have_attributes(legal_aid_regular: 222.22, maintenance_out_regular: 111.11)
-        # disposable_income_summary.reload
-        # expect(disposable_income_summary).to have_attributes(
-        #   maintenance_out_all_sources: 111.11,
-        # )
       end
 
       it "increments #total_outgoings_and_allowances" do
@@ -80,10 +72,6 @@ RSpec.describe Collators::RegularOutgoingsCollator do
 
       it "increments #<cagtegory>_all_sources data" do
         expect(collator).to have_attributes(legal_aid_regular: 240.74, maintenance_out_regular: 120.37)
-        # disposable_income_summary.reload
-        # expect(disposable_income_summary).to have_attributes(
-        #   maintenance_out_all_sources: 120.37,
-        # )
       end
 
       it "increments #total_outgoings_and_allowances" do
@@ -108,10 +96,6 @@ RSpec.describe Collators::RegularOutgoingsCollator do
 
       it "increments #<cagtegory>_all_sources data" do
         expect(collator).to have_attributes(legal_aid_regular: 481.48, maintenance_out_regular: 240.74)
-        # disposable_income_summary.reload
-        # expect(disposable_income_summary).to have_attributes(
-        #   maintenance_out_all_sources: 240.74,
-        # )
       end
 
       it "increments #total_outgoings_and_allowances" do
@@ -136,10 +120,6 @@ RSpec.describe Collators::RegularOutgoingsCollator do
 
       it "increments #<cagtegory>_all_sources data" do
         expect(collator).to have_attributes(legal_aid_regular: 962.95, maintenance_out_regular: 481.48)
-        # disposable_income_summary.reload
-        # expect(disposable_income_summary).to have_attributes(
-        #   maintenance_out_all_sources: 481.48,
-        # )
       end
 
       it "increments #total_outgoings_and_allowances" do
@@ -167,10 +147,6 @@ RSpec.describe Collators::RegularOutgoingsCollator do
           legal_aid_regular: 0.00,
           maintenance_out_regular: 0.0,
         )
-        # disposable_income_summary.reload
-        # expect(disposable_income_summary).to have_attributes(
-        #   maintenance_out_all_sources: 0.0,
-        # )
       end
 
       it "does not increment #total_outgoings_and_allowances" do
@@ -230,10 +206,6 @@ RSpec.describe Collators::RegularOutgoingsCollator do
 
       it "increments their values into single #<cagtegory>_all_sources data" do
         expect(collator).to have_attributes(maintenance_out_regular: 333.33)
-        # disposable_income_summary.reload
-        # expect(disposable_income_summary).to have_attributes(
-        #   maintenance_out_all_sources: 333.33,
-        # )
       end
 
       it "increments #total_outgoings_and_allowances" do
@@ -252,9 +224,6 @@ RSpec.describe Collators::RegularOutgoingsCollator do
     context "with existing data" do
       before do
         assessment.applicant_disposable_income_summary.update!(
-          maintenance_out_bank: 0.0,
-          maintenance_out_cash: 333.33,
-          maintenance_out_all_sources: 333.33,
           total_outgoings_and_allowances: 333.33,
           total_disposable_income: 9_666.66,
         )
@@ -262,9 +231,6 @@ RSpec.describe Collators::RegularOutgoingsCollator do
 
       it "has expected values prior to regular outgoings collation" do
         expect(disposable_income_summary).to have_attributes(
-          maintenance_out_bank: 0.0,
-          maintenance_out_cash: 333.33,
-          maintenance_out_all_sources: 333.33,
           total_outgoings_and_allowances: 333.33,
           total_disposable_income: 9_666.66,
         )
@@ -277,11 +243,7 @@ RSpec.describe Collators::RegularOutgoingsCollator do
         end
 
         it "increments #<category>_all_sources data to existing values" do
-          expect(collator).to have_attributes(legal_aid_regular: 2_000.00)
-          disposable_income_summary.reload
-          expect(disposable_income_summary).to have_attributes(
-            maintenance_out_all_sources: 1_333.33,
-          )
+          expect(collator).to have_attributes(legal_aid_regular: 2_000.00, maintenance_out_regular: 1_333.33)
         end
 
         it "increments #total_outgoings_and_allowances against existing value" do

--- a/spec/services/collators/regular_outgoings_collator_spec.rb
+++ b/spec/services/collators/regular_outgoings_collator_spec.rb
@@ -23,11 +23,11 @@ RSpec.describe Collators::RegularOutgoingsCollator do
 
     context "without monthly regular transactions" do
       it "does increments #<cagtegory>_all_sources data" do
-        expect(collator).to have_attributes(legal_aid_regular: 0.0)
-        disposable_income_summary.reload
-        expect(disposable_income_summary).to have_attributes(
-          maintenance_out_all_sources: 0.0,
-        )
+        expect(collator).to have_attributes(legal_aid_regular: 0.0, maintenance_out_regular: 0.0)
+        # disposable_income_summary.reload
+        # expect(disposable_income_summary).to have_attributes(
+        #   maintenance_out_all_sources: 0.0,
+        # )
       end
 
       it "does not increment #total_outgoings_and_allowances" do
@@ -51,11 +51,11 @@ RSpec.describe Collators::RegularOutgoingsCollator do
       end
 
       it "increments #<cagtegory>_all_sources data" do
-        expect(collator).to have_attributes(legal_aid_regular: 222.22)
-        disposable_income_summary.reload
-        expect(disposable_income_summary).to have_attributes(
-          maintenance_out_all_sources: 111.11,
-        )
+        expect(collator).to have_attributes(legal_aid_regular: 222.22, maintenance_out_regular: 111.11)
+        # disposable_income_summary.reload
+        # expect(disposable_income_summary).to have_attributes(
+        #   maintenance_out_all_sources: 111.11,
+        # )
       end
 
       it "increments #total_outgoings_and_allowances" do
@@ -79,11 +79,11 @@ RSpec.describe Collators::RegularOutgoingsCollator do
       end
 
       it "increments #<cagtegory>_all_sources data" do
-        expect(collator).to have_attributes(legal_aid_regular: 240.74)
-        disposable_income_summary.reload
-        expect(disposable_income_summary).to have_attributes(
-          maintenance_out_all_sources: 120.37,
-        )
+        expect(collator).to have_attributes(legal_aid_regular: 240.74, maintenance_out_regular: 120.37)
+        # disposable_income_summary.reload
+        # expect(disposable_income_summary).to have_attributes(
+        #   maintenance_out_all_sources: 120.37,
+        # )
       end
 
       it "increments #total_outgoings_and_allowances" do
@@ -107,11 +107,11 @@ RSpec.describe Collators::RegularOutgoingsCollator do
       end
 
       it "increments #<cagtegory>_all_sources data" do
-        expect(collator).to have_attributes(legal_aid_regular: 481.48)
-        disposable_income_summary.reload
-        expect(disposable_income_summary).to have_attributes(
-          maintenance_out_all_sources: 240.74,
-        )
+        expect(collator).to have_attributes(legal_aid_regular: 481.48, maintenance_out_regular: 240.74)
+        # disposable_income_summary.reload
+        # expect(disposable_income_summary).to have_attributes(
+        #   maintenance_out_all_sources: 240.74,
+        # )
       end
 
       it "increments #total_outgoings_and_allowances" do
@@ -135,11 +135,11 @@ RSpec.describe Collators::RegularOutgoingsCollator do
       end
 
       it "increments #<cagtegory>_all_sources data" do
-        expect(collator).to have_attributes(legal_aid_regular: 962.95)
-        disposable_income_summary.reload
-        expect(disposable_income_summary).to have_attributes(
-          maintenance_out_all_sources: 481.48,
-        )
+        expect(collator).to have_attributes(legal_aid_regular: 962.95, maintenance_out_regular: 481.48)
+        # disposable_income_summary.reload
+        # expect(disposable_income_summary).to have_attributes(
+        #   maintenance_out_all_sources: 481.48,
+        # )
       end
 
       it "increments #total_outgoings_and_allowances" do
@@ -165,11 +165,12 @@ RSpec.describe Collators::RegularOutgoingsCollator do
         expect(collator).to have_attributes(
           rent_or_mortgage_regular: 222.22,
           legal_aid_regular: 0.00,
+          maintenance_out_regular: 0.0,
         )
-        disposable_income_summary.reload
-        expect(disposable_income_summary).to have_attributes(
-          maintenance_out_all_sources: 0.0,
-        )
+        # disposable_income_summary.reload
+        # expect(disposable_income_summary).to have_attributes(
+        #   maintenance_out_all_sources: 0.0,
+        # )
       end
 
       it "does not increment #total_outgoings_and_allowances" do
@@ -228,11 +229,11 @@ RSpec.describe Collators::RegularOutgoingsCollator do
       end
 
       it "increments their values into single #<cagtegory>_all_sources data" do
-        collator
-        disposable_income_summary.reload
-        expect(disposable_income_summary).to have_attributes(
-          maintenance_out_all_sources: 333.33,
-        )
+        expect(collator).to have_attributes(maintenance_out_regular: 333.33)
+        # disposable_income_summary.reload
+        # expect(disposable_income_summary).to have_attributes(
+        #   maintenance_out_all_sources: 333.33,
+        # )
       end
 
       it "increments #total_outgoings_and_allowances" do

--- a/spec/services/decorators/v6/disposable_income_result_decorator_spec.rb
+++ b/spec/services/decorators/v6/disposable_income_result_decorator_spec.rb
@@ -11,7 +11,6 @@ module Decorators
       let(:summary) do
         create :disposable_income_summary,
                assessment:,
-               maintenance_out_all_sources: 330.21,
                total_outgoings_and_allowances: 660.21,
                total_disposable_income: 732.55,
                income_contribution: 75,
@@ -109,7 +108,8 @@ module Decorators
                                                             dependant_allowance: 220.21,
                                                             gross_housing_costs: 990.42,
                                                             housing_benefit: 440.21,
-                                                            net_housing_costs: 550.21)).as_json
+                                                            net_housing_costs: 550.21,
+                                                            maintenance_out_all_sources: 330.21)).as_json
       end
 
       before do


### PR DESCRIPTION
<!--Ticket-->
[LEP-271](https://dsdmoj.atlassian.net/browse/LEP-271)

Remove columns from disposable_income_summaries table

- maintenance_out_cash
- maintenance_out_bank
- maintenance_out_all_sources

[LEP-271]: https://dsdmoj.atlassian.net/browse/LEP-271?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ