### PR TITLE
EL-1078 update ruby version used by circleci to match CCQ version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -42,7 +42,7 @@ executors:
           - POSTGRES_DB=cfe_civil_test
   ccq-executor:
     docker:
-      - image: cimg/ruby:3.1.3-browsers
+      - image: cimg/ruby:3.2.2-browsers
         environment:
           VCR_RECORD_MODE: none
           COVERAGE: true


### PR DESCRIPTION

---
CCQ is updating its ruby version, this PR is to make sure that the end to end tests on circleCI do not break for cfe-civil after this change.

## Checklist

Before you ask people to review this PR:

- Diff - review it, ensuring it contains only expected changes
- Whitespace changes - avoid if possible, because they make diffs harder to read and conflicts more likely
- Changelog - add a line, if it meets the criteria
- Commit messages - say *why* the change was made
- PR description - summarizes *what* changed and *why*, with a JIRA ticket ID
- Tests pass - on CircleCI
- Conflicts - resolve if Github reports them. e.g. with `git rebase main`
