### PR TITLE
LEP-228 rename  some assessors to summarizers

### DIFF
--- a/app/services/capital_collator_and_assessor.rb
+++ b/app/services/capital_collator_and_assessor.rb
@@ -8,7 +8,7 @@ class CapitalCollatorAndAssessor
                                                       level_of_help: assessment.level_of_help,
                                                       pensioner_capital_disregard:, vehicles:)
       combined_assessed_capital = applicant_subtotals.assessed_capital
-      capital_contribution = Assessors::CapitalAssessor.call(assessment.applicant_capital_summary, combined_assessed_capital)
+      capital_contribution = Summarizers::CapitalSummarizer.call(assessment.applicant_capital_summary, combined_assessed_capital)
       CapitalSubtotals.new(
         applicant_capital_subtotals: applicant_subtotals,
         partner_capital_subtotals: PersonCapitalSubtotals.unassessed(vehicles: [], properties: []),
@@ -27,7 +27,7 @@ class CapitalCollatorAndAssessor
                                                   pensioner_capital_disregard: pensioner_capital_disregard - applicant_subtotals.pensioner_disregard_applied,
                                                   vehicles: partner_vehicles)
       combined_assessed_capital = applicant_subtotals.assessed_capital + partner_subtotals.assessed_capital
-      capital_contribution = Assessors::CapitalAssessor.call(assessment.applicant_capital_summary, combined_assessed_capital)
+      capital_contribution = Summarizers::CapitalSummarizer.call(assessment.applicant_capital_summary, combined_assessed_capital)
       CapitalSubtotals.new(
         applicant_capital_subtotals: applicant_subtotals,
         partner_capital_subtotals: partner_subtotals,

--- a/app/services/summarizers/assessment_proceeding_type_summarizer.rb
+++ b/app/services/summarizers/assessment_proceeding_type_summarizer.rb
@@ -1,5 +1,5 @@
-module Assessors
-  class AssessmentProceedingTypeAssessor
+module Summarizers
+  class AssessmentProceedingTypeSummarizer
     # this class examines the assessment results on capital, gross_income and
     # disposable income _eligibility records for the specified proceeding type code
     # and updates the corresponding assessment_eligibility records with an overall

--- a/app/services/summarizers/capital_summarizer.rb
+++ b/app/services/summarizers/capital_summarizer.rb
@@ -1,5 +1,5 @@
-module Assessors
-  class CapitalAssessor
+module Summarizers
+  class CapitalSummarizer
     class << self
       def call(capital_summary, assessed_capital)
         capital_summary.eligibilities.each { |elig| elig.update_assessment_result! assessed_capital }

--- a/app/services/summarizers/disposable_income_summarizer.rb
+++ b/app/services/summarizers/disposable_income_summarizer.rb
@@ -1,5 +1,5 @@
-module Assessors
-  class DisposableIncomeAssessor
+module Summarizers
+  class DisposableIncomeSummarizer
     class << self
       def call(total_disposable_income:, disposable_income_summary:, submission_date:)
         new(total_disposable_income:, disposable_income_summary:, submission_date:).call

--- a/app/services/summarizers/gross_income_summarizer.rb
+++ b/app/services/summarizers/gross_income_summarizer.rb
@@ -1,5 +1,5 @@
-module Assessors
-  class GrossIncomeAssessor
+module Summarizers
+  class GrossIncomeSummarizer
     class << self
       def call(eligibilities:, total_gross_income:)
         eligibilities.each { |e| e.update_assessment_result! total_gross_income }

--- a/app/services/summarizers/main_summarizer.rb
+++ b/app/services/summarizers/main_summarizer.rb
@@ -1,10 +1,10 @@
-module Assessors
-  class MainAssessor
+module Summarizers
+  class MainSummarizer
     class << self
       def call(assessment:, receives_qualifying_benefit:, receives_asylum_support:)
         assessment.proceeding_types.map(&:ccms_code).each do |ptc|
-          AssessmentProceedingTypeAssessor.call(assessment:, proceeding_type_code: ptc,
-                                                receives_qualifying_benefit:, receives_asylum_support:)
+          Assessors::AssessmentProceedingTypeAssessor.call(assessment:, proceeding_type_code: ptc,
+                                                           receives_qualifying_benefit:, receives_asylum_support:)
         end
         assessment.update!(assessment_result: summarized_result(assessment.eligibilities))
       end

--- a/app/services/summarizers/main_summarizer.rb
+++ b/app/services/summarizers/main_summarizer.rb
@@ -3,8 +3,8 @@ module Summarizers
     class << self
       def call(assessment:, receives_qualifying_benefit:, receives_asylum_support:)
         assessment.proceeding_types.map(&:ccms_code).each do |ptc|
-          Assessors::AssessmentProceedingTypeAssessor.call(assessment:, proceeding_type_code: ptc,
-                                                           receives_qualifying_benefit:, receives_asylum_support:)
+          Summarizers::AssessmentProceedingTypeSummarizer.call(assessment:, proceeding_type_code: ptc,
+                                                               receives_qualifying_benefit:, receives_asylum_support:)
         end
         assessment.update!(assessment_result: summarized_result(assessment.eligibilities))
       end

--- a/app/services/workflows/main_workflow.rb
+++ b/app/services/workflows/main_workflow.rb
@@ -43,8 +43,8 @@ module Workflows
                                                              assessed_capital: calculation_output.capital_subtotals.combined_assessed_capital)
         end
         assessment.add_remarks!(new_remarks)
-        Assessors::MainAssessor.call(assessment:, receives_qualifying_benefit: applicant.details.receives_qualifying_benefit?,
-                                     receives_asylum_support: applicant.details.receives_asylum_support)
+        Summarizers::MainSummarizer.call(assessment:, receives_qualifying_benefit: applicant.details.receives_qualifying_benefit?,
+                                         receives_asylum_support: applicant.details.receives_asylum_support)
         calculation_output
       end
 

--- a/app/services/workflows/non_passported_workflow.rb
+++ b/app/services/workflows/non_passported_workflow.rb
@@ -58,7 +58,7 @@ module Workflows
                               single_disposable_income_assessment(assessment:, gross_income_subtotals:,
                                                                   applicant_person_data: applicant)
                             end
-        income_contribution = Assessors::DisposableIncomeAssessor.call(
+        income_contribution = Summarizers::DisposableIncomeSummarizer.call(
           disposable_income_summary: assessment.applicant_disposable_income_summary,
           total_disposable_income: disposable_result.combined_total_disposable_income,
           submission_date: assessment.submission_date,

--- a/app/services/workflows/non_passported_workflow.rb
+++ b/app/services/workflows/non_passported_workflow.rb
@@ -161,7 +161,7 @@ module Workflows
           self_employments:,
           partner_self_employments:,
         ).tap do |gross_income_subtotals|
-          Assessors::GrossIncomeAssessor.call(
+          Summarizers::GrossIncomeSummarizer.call(
             eligibilities: assessment.applicant_gross_income_summary.eligibilities,
             total_gross_income: gross_income_subtotals.combined_monthly_gross_income,
           )

--- a/spec/services/summarizers/assessment_proceeding_type_summarizer_spec.rb
+++ b/spec/services/summarizers/assessment_proceeding_type_summarizer_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
-module Assessors
-  RSpec.describe AssessmentProceedingTypeAssessor do
+module Summarizers
+  RSpec.describe AssessmentProceedingTypeSummarizer do
     let(:assessment) do
       create :assessment,
              :with_capital_summary,
@@ -215,7 +215,7 @@ module Assessors
         begin
           described_class.call(assessment:, proceeding_type_code: ptc, receives_qualifying_benefit:, receives_asylum_support:)
         rescue StandardError => e
-          raise "Unexpected exception: #{e.class}" unless e.is_a?(Assessors::AssessmentProceedingTypeAssessor::AssessmentError)
+          raise "Unexpected exception: #{e.class}" unless e.is_a?(Summarizers::AssessmentProceedingTypeSummarizer::AssessmentError)
 
           return e.message
         end

--- a/spec/services/summarizers/disposable_income_summarizer_spec.rb
+++ b/spec/services/summarizers/disposable_income_summarizer_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
-module Assessors
-  RSpec.describe DisposableIncomeAssessor do
+module Summarizers
+  RSpec.describe DisposableIncomeSummarizer do
     describe ".call" do
       let(:assessment) { disposable_income_summary.assessment }
       let(:disposable_income_summary) { create :disposable_income_summary }

--- a/spec/services/summarizers/gross_income_summarizer_spec.rb
+++ b/spec/services/summarizers/gross_income_summarizer_spec.rb
@@ -1,12 +1,12 @@
 require "rails_helper"
 
-module Assessors
-  RSpec.describe GrossIncomeAssessor do
+module Summarizers
+  RSpec.describe GrossIncomeSummarizer do
     let(:assessment) { create :assessment, :with_gross_income_summary }
     let(:gross_income_summary) { assessment.applicant_gross_income_summary }
 
     describe ".call" do
-      subject(:assessor) do
+      subject(:summarizer) do
         described_class.call(eligibilities: gross_income_summary.eligibilities,
                              total_gross_income:)
       end
@@ -17,7 +17,7 @@ module Assessors
 
           it "is eligible" do
             create :gross_income_eligibility, gross_income_summary:, upper_threshold: 2_567
-            assessor
+            summarizer
             expect(gross_income_summary.summarized_assessment_result).to eq :eligible
           end
         end
@@ -27,7 +27,7 @@ module Assessors
 
           it "is not eligible" do
             create :gross_income_eligibility, gross_income_summary:, upper_threshold: 2_567
-            assessor
+            summarizer
             expect(gross_income_summary.summarized_assessment_result).to eq :ineligible
           end
         end
@@ -37,7 +37,7 @@ module Assessors
 
           it "is not eligible" do
             create :gross_income_eligibility, gross_income_summary:, upper_threshold: 2_567
-            assessor
+            summarizer
             expect(gross_income_summary.summarized_assessment_result).to eq :ineligible
           end
         end

--- a/spec/services/summarizers/main_summarizer_spec.rb
+++ b/spec/services/summarizers/main_summarizer_spec.rb
@@ -10,13 +10,13 @@ module Summarizers
              proceedings: [%w[DA003 A], %w[SE014 Z]]
     end
 
-    subject(:assessor) { described_class.call(assessment:, receives_qualifying_benefit: false, receives_asylum_support: false) }
+    subject(:summarizer) { described_class.call(assessment:, receives_qualifying_benefit: false, receives_asylum_support: false) }
 
     context "AssessmentProceedingTypeAssessor" do
       it "calls AssessmentProceedingTypeAssessor for each proceeding type code" do
         expect(Assessors::AssessmentProceedingTypeAssessor).to receive(:call).with(assessment:, proceeding_type_code: "DA003", receives_qualifying_benefit: false, receives_asylum_support: false)
         expect(Assessors::AssessmentProceedingTypeAssessor).to receive(:call).with(assessment:, proceeding_type_code: "SE014", receives_qualifying_benefit: false, receives_asylum_support: false)
-        assessor
+        summarizer
       end
     end
 
@@ -32,7 +32,7 @@ module Summarizers
       it "calls the Results summarizer to update the assessment result" do
         expect(Utilities::ResultSummarizer).to receive(:call).with(%w[eligible ineligible]).and_call_original
 
-        assessor
+        summarizer
         expect(assessment.assessment_result).to eq "partially_eligible"
       end
     end

--- a/spec/services/summarizers/main_summarizer_spec.rb
+++ b/spec/services/summarizers/main_summarizer_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
-module Assessors
-  RSpec.describe MainAssessor do
+module Summarizers
+  RSpec.describe MainSummarizer do
     let(:assessment) do
       create :assessment,
              :with_capital_summary,
@@ -14,8 +14,8 @@ module Assessors
 
     context "AssessmentProceedingTypeAssessor" do
       it "calls AssessmentProceedingTypeAssessor for each proceeding type code" do
-        expect(AssessmentProceedingTypeAssessor).to receive(:call).with(assessment:, proceeding_type_code: "DA003", receives_qualifying_benefit: false, receives_asylum_support: false)
-        expect(AssessmentProceedingTypeAssessor).to receive(:call).with(assessment:, proceeding_type_code: "SE014", receives_qualifying_benefit: false, receives_asylum_support: false)
+        expect(Assessors::AssessmentProceedingTypeAssessor).to receive(:call).with(assessment:, proceeding_type_code: "DA003", receives_qualifying_benefit: false, receives_asylum_support: false)
+        expect(Assessors::AssessmentProceedingTypeAssessor).to receive(:call).with(assessment:, proceeding_type_code: "SE014", receives_qualifying_benefit: false, receives_asylum_support: false)
         assessor
       end
     end
@@ -25,8 +25,8 @@ module Assessors
         create :assessment_eligibility, assessment:, proceeding_type_code: "DA003", assessment_result: "eligible"
         create :assessment_eligibility, assessment:, proceeding_type_code: "SE014", assessment_result: "ineligible"
 
-        allow(AssessmentProceedingTypeAssessor).to receive(:call).with(assessment:, proceeding_type_code: "DA003", receives_qualifying_benefit: false, receives_asylum_support: false)
-        allow(AssessmentProceedingTypeAssessor).to receive(:call).with(assessment:, proceeding_type_code: "SE014", receives_qualifying_benefit: false, receives_asylum_support: false)
+        allow(Assessors::AssessmentProceedingTypeAssessor).to receive(:call).with(assessment:, proceeding_type_code: "DA003", receives_qualifying_benefit: false, receives_asylum_support: false)
+        allow(Assessors::AssessmentProceedingTypeAssessor).to receive(:call).with(assessment:, proceeding_type_code: "SE014", receives_qualifying_benefit: false, receives_asylum_support: false)
       end
 
       it "calls the Results summarizer to update the assessment result" do

--- a/spec/services/summarizers/main_summarizer_spec.rb
+++ b/spec/services/summarizers/main_summarizer_spec.rb
@@ -12,10 +12,10 @@ module Summarizers
 
     subject(:summarizer) { described_class.call(assessment:, receives_qualifying_benefit: false, receives_asylum_support: false) }
 
-    context "AssessmentProceedingTypeAssessor" do
-      it "calls AssessmentProceedingTypeAssessor for each proceeding type code" do
-        expect(Assessors::AssessmentProceedingTypeAssessor).to receive(:call).with(assessment:, proceeding_type_code: "DA003", receives_qualifying_benefit: false, receives_asylum_support: false)
-        expect(Assessors::AssessmentProceedingTypeAssessor).to receive(:call).with(assessment:, proceeding_type_code: "SE014", receives_qualifying_benefit: false, receives_asylum_support: false)
+    context "AssessmentProceedingTypeSummarizer" do
+      it "calls AssessmentProceedingTypeSummarizer for each proceeding type code" do
+        expect(Summarizers::AssessmentProceedingTypeSummarizer).to receive(:call).with(assessment:, proceeding_type_code: "DA003", receives_qualifying_benefit: false, receives_asylum_support: false)
+        expect(Summarizers::AssessmentProceedingTypeSummarizer).to receive(:call).with(assessment:, proceeding_type_code: "SE014", receives_qualifying_benefit: false, receives_asylum_support: false)
         summarizer
       end
     end
@@ -25,8 +25,8 @@ module Summarizers
         create :assessment_eligibility, assessment:, proceeding_type_code: "DA003", assessment_result: "eligible"
         create :assessment_eligibility, assessment:, proceeding_type_code: "SE014", assessment_result: "ineligible"
 
-        allow(Assessors::AssessmentProceedingTypeAssessor).to receive(:call).with(assessment:, proceeding_type_code: "DA003", receives_qualifying_benefit: false, receives_asylum_support: false)
-        allow(Assessors::AssessmentProceedingTypeAssessor).to receive(:call).with(assessment:, proceeding_type_code: "SE014", receives_qualifying_benefit: false, receives_asylum_support: false)
+        allow(Summarizers::AssessmentProceedingTypeSummarizer).to receive(:call).with(assessment:, proceeding_type_code: "DA003", receives_qualifying_benefit: false, receives_asylum_support: false)
+        allow(Summarizers::AssessmentProceedingTypeSummarizer).to receive(:call).with(assessment:, proceeding_type_code: "SE014", receives_qualifying_benefit: false, receives_asylum_support: false)
       end
 
       it "calls the Results summarizer to update the assessment result" do

--- a/spec/services/workflows/main_workflow_spec.rb
+++ b/spec/services/workflows/main_workflow_spec.rb
@@ -25,7 +25,7 @@ module Workflows
 
       it "calls normal workflows by default" do
         allow(PassportedWorkflow).to receive(:call).and_return(calculation_output)
-        expect(Assessors::MainAssessor).to receive(:call).with(assessment:, receives_asylum_support: true, receives_qualifying_benefit: false)
+        expect(Summarizers::MainSummarizer).to receive(:call).with(assessment:, receives_asylum_support: true, receives_qualifying_benefit: false)
         described_class.call(assessment:,
                              applicant: build(:person_data, details: applicant),
                              partner: nil)
@@ -37,7 +37,7 @@ module Workflows
         it "does not call a workflow" do
           expect(PassportedWorkflow).not_to receive(:call)
           expect(NonPassportedWorkflow).not_to receive(:call)
-          expect(Assessors::MainAssessor).to receive(:call).with(assessment:, receives_asylum_support: true, receives_qualifying_benefit: false)
+          expect(Summarizers::MainSummarizer).to receive(:call).with(assessment:, receives_asylum_support: true, receives_qualifying_benefit: false)
           described_class.call(assessment:,
                                applicant: build(:person_data, details: applicant),
                                partner: nil)
@@ -56,16 +56,16 @@ module Workflows
         end
 
         it "calls PassportedWorkflow" do
-          allow(Assessors::MainAssessor).to receive(:call)
+          allow(Summarizers::MainSummarizer).to receive(:call)
           allow(PassportedWorkflow).to receive(:call).with(assessment:, vehicles: [],
                                                            date_of_birth: applicant.date_of_birth,
                                                            receives_qualifying_benefit: true).and_return(calculation_output)
           workflow_call
         end
 
-        it "calls MainAssessor" do
+        it "calls MainSummarizer" do
           allow(PassportedWorkflow).to receive(:call).and_return(calculation_output)
-          expect(Assessors::MainAssessor).to receive(:call).with(assessment:, receives_asylum_support: false, receives_qualifying_benefit: true)
+          expect(Summarizers::MainSummarizer).to receive(:call).with(assessment:, receives_asylum_support: false, receives_qualifying_benefit: true)
           workflow_call
         end
       end
@@ -86,7 +86,7 @@ module Workflows
         end
 
         it "calls PassportedWorkflow" do
-          allow(Assessors::MainAssessor).to receive(:call)
+          allow(Summarizers::MainSummarizer).to receive(:call)
           expect(PassportedWorkflow).to receive(:partner).with(assessment:, vehicles: [], partner_vehicles: [],
                                                                partner_date_of_birth: partner.date_of_birth,
                                                                date_of_birth: applicant.date_of_birth,
@@ -106,14 +106,14 @@ module Workflows
       end
 
       it "calls NonPassportedWorkflow" do
-        allow(Assessors::MainAssessor).to receive(:call)
+        allow(Summarizers::MainSummarizer).to receive(:call)
         allow(NonPassportedWorkflow).to receive(:call).and_return(calculation_output)
         workflow_call
       end
 
-      it "calls MainAssessor" do
+      it "calls MainSummarizer" do
         allow(NonPassportedWorkflow).to receive(:call).and_return(calculation_output)
-        expect(Assessors::MainAssessor).to receive(:call).with(assessment:, receives_asylum_support: false, receives_qualifying_benefit: false)
+        expect(Summarizers::MainSummarizer).to receive(:call).with(assessment:, receives_asylum_support: false, receives_qualifying_benefit: false)
         workflow_call
       end
     end
@@ -143,7 +143,7 @@ module Workflows
 
           expect(Creators::EligibilitiesCreator).to receive(:call).with(assessment:, client_dependants: [], partner_dependants: [])
           allow(NonPassportedWorkflow).to receive(:call).and_return(calculation_output)
-          allow(Assessors::MainAssessor).to receive(:call).with(assessment:, receives_asylum_support: false, receives_qualifying_benefit: false)
+          allow(Summarizers::MainSummarizer).to receive(:call).with(assessment:, receives_asylum_support: false, receives_qualifying_benefit: false)
           allow(RemarkGenerators::Orchestrator).to receive(:call).with(employments: assessment.employments,
                                                                        lower_capital_threshold: 3000,
                                                                        child_care_bank: 0,
@@ -160,7 +160,7 @@ module Workflows
 
           allow(Utilities::ProceedingTypeThresholdPopulator).to receive(:call).with(assessment)
           allow(NonPassportedWorkflow).to receive(:call).and_return(calculation_output)
-          allow(Assessors::MainAssessor).to receive(:call).with(assessment:, receives_qualifying_benefit: false, receives_asylum_support: false)
+          allow(Summarizers::MainSummarizer).to receive(:call).with(assessment:, receives_qualifying_benefit: false, receives_asylum_support: false)
           allow(RemarkGenerators::Orchestrator).to receive(:call).with(employments: assessment.employments,
                                                                        lower_capital_threshold: 3000,
                                                                        child_care_bank: 0,

--- a/spec/services/workflows/non_passported_workflow_spec.rb
+++ b/spec/services/workflows/non_passported_workflow_spec.rb
@@ -37,7 +37,7 @@ module Workflows
       subject(:calculation_output) do
         assessment.reload
         described_class.call(assessment:, applicant: person_applicant, partner: partner_applicant).tap do
-          Assessors::MainAssessor.call(assessment:, receives_qualifying_benefit: false, receives_asylum_support: false)
+          Summarizers::MainSummarizer.call(assessment:, receives_qualifying_benefit: false, receives_asylum_support: false)
         end
       end
 
@@ -85,7 +85,7 @@ module Workflows
         assessment.reload
         described_class.call(assessment:, applicant: build(:person_data, details: applicant, dependants:),
                              partner: partner.present? ? build(:person_data, details: partner) : nil)
-        Assessors::MainAssessor.call(assessment:, receives_qualifying_benefit: false, receives_asylum_support: false)
+        Summarizers::MainSummarizer.call(assessment:, receives_qualifying_benefit: false, receives_asylum_support: false)
         assessment.assessment_result
       end
 
@@ -106,7 +106,7 @@ module Workflows
             described_class.call(assessment:,
                                  applicant: build(:person_data, details: build(:applicant), self_employments:),
                                  partner:).tap do
-              Assessors::MainAssessor.call(assessment:, receives_qualifying_benefit: false, receives_asylum_support: false)
+              Summarizers::MainSummarizer.call(assessment:, receives_qualifying_benefit: false, receives_asylum_support: false)
             end
           end
           let(:employment_income_subtotals) { calculation_output.gross_income_subtotals.applicant_gross_income_subtotals.employment_income_subtotals }

--- a/spec/services/workflows/passported_workflow_spec.rb
+++ b/spec/services/workflows/passported_workflow_spec.rb
@@ -31,10 +31,10 @@ module Workflows
         expect(result.capital_subtotals.combined_assessed_capital).to eq capital_data.assessed_capital
       end
 
-      it "calls CapitalAssessor and updates capital summary record with result" do
+      it "calls CapitalSummarizer and updates capital summary record with result" do
         allow(Collators::CapitalCollator).to receive(:call).and_return(capital_data)
         expect(Collators::CapitalCollator).to receive(:call)
-        expect(Assessors::CapitalAssessor).to receive(:call).and_call_original
+        expect(Summarizers::CapitalSummarizer).to receive(:call).and_call_original
         workflow_call
         expect(applicant_capital_summary.summarized_assessment_result).to eq :eligible
       end


### PR DESCRIPTION
<!--Ticket-->
[LEP-228](https://dsdmoj.atlassian.net/browse/LEP-228)

Rename following Accessors to Summarizers
- Assessors::AssessmentProceedingTypeAssessor -> Summarizers::AssessmentProceedingTypeSummarizer
- Assessors::CapitalAssessor -> Summarizers::CapitalSummarizer
- Assessors::DisposableIncomeAssessor -> Summarizers::DisposableIncomeSummarizer
- Assessors::GrossIncomeAssessor -> Summarizers::GrossIncomeSummarizer
- Assessors::MainAssessor -> Summarizers::MainSummarizer



[LEP-228]: https://dsdmoj.atlassian.net/browse/LEP-228?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ