### PR TITLE
Refactor housing calculations

### DIFF
--- a/app/lib/person_disposable_income_subtotals.rb
+++ b/app/lib/person_disposable_income_subtotals.rb
@@ -68,11 +68,11 @@ class PersonDisposableIncomeSubtotals
   end
 
   def rent_or_mortgage_cash
-    @disposable.rent_or_mortgage_cash
+    @outgoings.housing_costs.gross_housing_costs_cash
   end
 
   def rent_or_mortgage_all_sources
-    rent_or_mortgage_bank + rent_or_mortgage_cash + @regular.rent_or_mortgage_regular
+    rent_or_mortgage_bank + rent_or_mortgage_cash + @outgoings.housing_costs.gross_housing_costs_regular
   end
 
   def legal_aid_bank

--- a/app/services/collators/disposable_income_collator.rb
+++ b/app/services/collators/disposable_income_collator.rb
@@ -1,16 +1,15 @@
 module Collators
   class DisposableIncomeCollator
-    Result = Data.define(:rent_or_mortgage_cash, :legal_aid_cash, :maintenance_out_cash) do
+    Result = Data.define(:legal_aid_cash, :maintenance_out_cash) do
       def self.blank
-        new(rent_or_mortgage_cash: 0, legal_aid_cash: 0, maintenance_out_cash: 0)
+        new(legal_aid_cash: 0, maintenance_out_cash: 0)
       end
     end
 
     class << self
       def call(gross_income_summary:)
         Result.new(legal_aid_cash: monthly_cash_by_category(gross_income_summary, :legal_aid),
-                   maintenance_out_cash: monthly_cash_by_category(gross_income_summary, :maintenance_out),
-                   rent_or_mortgage_cash: monthly_cash_by_category(gross_income_summary, :rent_or_mortgage))
+                   maintenance_out_cash: monthly_cash_by_category(gross_income_summary, :maintenance_out))
       end
 
       def monthly_cash_by_category(gross_income_summary, category)

--- a/app/services/collators/housing_costs_collator.rb
+++ b/app/services/collators/housing_costs_collator.rb
@@ -1,17 +1,23 @@
 module Collators
   class HousingCostsCollator
-    Result = Data.define(:housing_benefit, :gross_housing_costs, :gross_housing_costs_bank, :net_housing_costs) do
+    Result = Data.define(:housing_benefit, :gross_housing_costs, :gross_housing_costs_bank, :net_housing_costs,
+                         :gross_housing_costs_cash, :gross_housing_costs_regular) do
       def self.blank
         new(housing_benefit: 0,
             gross_housing_costs: 0,
             gross_housing_costs_bank: 0,
+            gross_housing_costs_cash: 0,
+            gross_housing_costs_regular: 0,
             net_housing_costs: 0)
       end
     end
 
     class << self
       def call(housing_cost_outgoings:, gross_income_summary:, submission_date:, person:, allow_negative_net:)
+        monthly_housing_benefit = monthly_housing_benefit(gross_income_summary)
+
         housing_calculator = Calculators::HousingCostsCalculator.call(housing_cost_outgoings:, gross_income_summary:,
+                                                                      monthly_housing_benefit:,
                                                                       submission_date:, housing_costs_cap_applies: housing_costs_cap_applies?(person))
 
         net_housing_costs = if allow_negative_net
@@ -21,11 +27,31 @@ module Collators
                             end
 
         Result.new(
-          housing_benefit: housing_calculator.monthly_housing_benefit,
+          housing_benefit: monthly_housing_benefit,
           gross_housing_costs: housing_calculator.gross_housing_costs,
           gross_housing_costs_bank: housing_calculator.gross_housing_costs_bank,
+          gross_housing_costs_cash: housing_calculator.gross_housing_costs_cash,
+          gross_housing_costs_regular: housing_calculator.gross_housing_costs_regular,
           net_housing_costs:,
         )
+      end
+
+    private
+
+      def monthly_housing_benefit(gross_income_summary)
+        housing_benefit_payments = Calculators::MonthlyEquivalentCalculator.call(
+          collection: housing_benefit_records(gross_income_summary),
+        )
+        housing_benefit_payments + monthly_housing_benefit_regular_transactions(gross_income_summary)
+      end
+
+      def monthly_housing_benefit_regular_transactions(gross_income_summary)
+        txns = gross_income_summary.regular_transactions.with_operation_and_category(:credit, :housing_benefit)
+        Calculators::MonthlyRegularTransactionAmountCalculator.call(txns)
+      end
+
+      def housing_benefit_records(gross_income_summary)
+        gross_income_summary.housing_benefit_payments
       end
 
       def housing_costs_cap_applies?(person)

--- a/app/services/collators/regular_outgoings_collator.rb
+++ b/app/services/collators/regular_outgoings_collator.rb
@@ -11,9 +11,9 @@
 #
 module Collators
   class RegularOutgoingsCollator
-    Result = Data.define(:child_care_regular, :rent_or_mortgage_regular, :legal_aid_regular, :maintenance_out_regular) do
+    Result = Data.define(:child_care_regular, :legal_aid_regular, :maintenance_out_regular) do
       def self.blank
-        new(child_care_regular: 0, rent_or_mortgage_regular: 0, legal_aid_regular: 0, maintenance_out_regular: 0)
+        new(child_care_regular: 0, legal_aid_regular: 0, maintenance_out_regular: 0)
       end
     end
 
@@ -26,7 +26,6 @@ module Collators
                                    end
 
         Result.new(child_care_regular: childcare_monthly_amount,
-                   rent_or_mortgage_regular: regular_amount_for(gross_income_summary, :rent_or_mortgage),
                    legal_aid_regular: regular_amount_for(gross_income_summary, :legal_aid),
                    maintenance_out_regular: regular_amount_for(gross_income_summary, :maintenance_out))
       end

--- a/spec/services/calculators/housing_costs_calculator_spec.rb
+++ b/spec/services/calculators/housing_costs_calculator_spec.rb
@@ -3,23 +3,22 @@ require "rails_helper"
 module Calculators
   RSpec.describe HousingCostsCalculator, :calls_bank_holiday do
     let(:housing_benefit_type) { create :state_benefit_type, label: "housing_benefit" }
+    let(:assessment) do
+      create :assessment, :with_gross_income_summary,
+             :with_disposable_income_summary,
+             submission_date:
+    end
 
     subject(:calculator) do
       described_class.call(housing_cost_outgoings:,
-                           housing_costs_cap_applies: children.zero?,
+                           housing_costs_cap_applies:,
+                           monthly_housing_benefit: housing_benefit_amount,
                            submission_date: assessment.submission_date,
                            gross_income_summary: assessment.applicant_gross_income_summary)
     end
 
     context "when using outgoings and state_benefits" do
       let(:submission_date) { Date.new(2022, 6, 6) }
-      let(:assessment) do
-        create :assessment, :with_gross_income_summary,
-               :with_disposable_income_summary,
-               submission_date:
-      end
-      let(:rent_or_mortgage_transactions) { rent_or_mortgage_category.cash_transactions.order(:date) }
-      let(:rent_or_mortgage_category) { create(:rent_or_mortgage_transaction_category, gross_income_summary: assessment.applicant_gross_income_summary) }
 
       let(:housing_cost_outgoings) do
         [submission_date - 2.months, submission_date - 1.month, submission_date].map do |date|
@@ -32,9 +31,11 @@ module Calculators
 
       context "when applicant has no dependants" do
         let(:housing_cost_amount) { 1200.00 }
-        let(:children) { 0 }
+        let(:housing_costs_cap_applies) { true }
 
         context "and does not receive housing benefit" do
+          let(:housing_benefit_amount) { 0 }
+
           context "with board and lodging" do
             let(:housing_cost_type) { "board_and_lodging" }
             let(:housing_cost_amount) { 1500.00 }
@@ -42,23 +43,7 @@ module Calculators
             it "caps the return" do
               expect(calculator)
                 .to have_attributes(gross_housing_costs: 750.00,
-                                    monthly_housing_benefit: 0.0,
                                     net_housing_costs: 545.00) # Cap applied
-            end
-
-            context "when 50% of monthly bank outgoings are below the cap but overall above it when including cash payments" do
-              before do
-                create(:cash_transaction, cash_transaction_category: rent_or_mortgage_category, amount: 20)
-              end
-
-              let(:housing_cost_amount) { 1088.00 }
-
-              it "caps the net costs" do
-                expect(calculator)
-                  .to have_attributes(gross_housing_costs: 564.00,
-                                      monthly_housing_benefit: 0.0,
-                                      net_housing_costs: 545.00) # Cap applied
-              end
             end
 
             context "when 50% of monthly bank and cash outgoings are below the cap" do
@@ -68,34 +53,7 @@ module Calculators
                 expect(calculator)
                   .to have_attributes(
                     gross_housing_costs: 444.0,
-                    monthly_housing_benefit: 0.0,
                     net_housing_costs: 444.0,
-                  )
-              end
-            end
-          end
-
-          context "with rent" do
-            let(:housing_cost_type) { "rent" }
-
-            it "caps the return" do
-              expect(calculator)
-                .to have_attributes(
-                  gross_housing_costs: 1200.0,
-                  monthly_housing_benefit: 0.0,
-                  net_housing_costs: 545.0, # Cap applied
-                )
-            end
-
-            context "when net cost is below housing cap" do
-              let(:housing_cost_amount) { 420.00 }
-
-              it "returns the net cost" do
-                expect(calculator)
-                  .to have_attributes(
-                    gross_housing_costs: 420.0,
-                    monthly_housing_benefit: 0.0,
-                    net_housing_costs: 420.0,
                   )
               end
             end
@@ -108,7 +66,6 @@ module Calculators
               expect(calculator)
                 .to have_attributes(
                   gross_housing_costs: 1200.0,
-                  monthly_housing_benefit: 0.0,
                   net_housing_costs: 545.0, # Cap applied
                 )
             end
@@ -120,7 +77,6 @@ module Calculators
                 expect(calculator)
                   .to have_attributes(
                     gross_housing_costs: 420.0,
-                    monthly_housing_benefit: 0.0,
                     net_housing_costs: 420.0,
                   )
               end
@@ -131,12 +87,6 @@ module Calculators
         context "and receives housing benefit as a state_benefit" do
           let(:housing_benefit_amount) { 500.00 }
 
-          before do
-            create :state_benefit, :with_monthly_payments,
-                   payment_amount: housing_benefit_amount,
-                   gross_income_summary: assessment.applicant_gross_income_summary, state_benefit_type: housing_benefit_type
-          end
-
           context "with board and lodging" do
             let(:housing_cost_type) { "board_and_lodging" }
             let(:housing_cost_amount) { 1500.00 }
@@ -146,7 +96,6 @@ module Calculators
               expect(calculator)
                 .to have_attributes(
                   gross_housing_costs: 750.0,
-                  monthly_housing_benefit: 100.0,
                   net_housing_costs: 545.0, # Cap applied
                 )
             end
@@ -159,7 +108,6 @@ module Calculators
               expect(calculator)
                 .to have_attributes(
                   gross_housing_costs: 1200.0,
-                  monthly_housing_benefit: 500.0,
                   net_housing_costs: 545.0, # Cap applied
                 )
             end
@@ -172,34 +120,6 @@ module Calculators
                 expect(calculator)
                   .to have_attributes(
                     gross_housing_costs: 1000.0,
-                    monthly_housing_benefit: 600.0,
-                    net_housing_costs: 400.0,
-                  )
-              end
-            end
-          end
-
-          context "with mortgage" do
-            let(:housing_cost_type) { "mortgage" }
-
-            it "caps the return" do
-              expect(calculator)
-                .to have_attributes(
-                  gross_housing_costs: 1200.0,
-                  monthly_housing_benefit: 500.0,
-                  net_housing_costs: 545.0, # Cap applied
-                )
-            end
-
-            context "when net amount will be below the cap" do
-              let(:housing_cost_amount) { 600.00 }
-              let(:housing_benefit_amount) { 200.00 }
-
-              it "returns net as gross_cost minus housing_benefit" do
-                expect(calculator)
-                  .to have_attributes(
-                    gross_housing_costs: 600.0,
-                    monthly_housing_benefit: 200.0,
                     net_housing_costs: 400.0,
                   )
               end
@@ -209,10 +129,12 @@ module Calculators
       end
 
       context "when applicant has dependants" do
-        let(:children) { 1 }
+        let(:housing_costs_cap_applies) { false }
         let(:housing_cost_amount) { 1200.00 }
 
         context "with no housing benefit" do
+          let(:housing_benefit_amount) { 0 }
+
           context "board and lodging" do
             let(:housing_cost_type) { "board_and_lodging" }
 
@@ -220,7 +142,6 @@ module Calculators
               expect(calculator)
                 .to have_attributes(
                   gross_housing_costs: 600.00,
-                  monthly_housing_benefit: 0.0,
                   net_housing_costs: 600.00,
                 )
             end
@@ -233,51 +154,14 @@ module Calculators
               expect(calculator)
                 .to have_attributes(
                   gross_housing_costs: 1200.00,
-                  monthly_housing_benefit: 0.0,
                   net_housing_costs: 1200.00,
                 )
             end
-          end
-
-          context "mortgage" do
-            let(:housing_cost_type) { "mortgage" }
-
-            it "records the full monthly housing costs" do
-              expect(calculator)
-                .to have_attributes(
-                  gross_housing_costs: 1200.00,
-                  monthly_housing_benefit: 0.0,
-                  net_housing_costs: 1200.00,
-                )
-            end
-          end
-        end
-
-        context "with weekly housing benefit" do
-          let(:housing_benefit_amount) { 500.00 }
-          let(:housing_cost_type) { "rent" }
-          let(:state_benefit) { create :state_benefit, gross_income_summary: assessment.applicant_gross_income_summary, state_benefit_type: housing_benefit_type }
-
-          before do
-            [submission_date - 4.weeks, submission_date - 3.weeks, submission_date - 2.weeks, submission_date - 1.week, submission_date].each do |pay_date|
-              create :state_benefit_payment, state_benefit:, amount: housing_benefit_amount, payment_date: pay_date
-            end
-          end
-
-          it "records the full monthly housing costs" do
-            expect(calculator).to have_attributes(gross_housing_costs: 1200.00,
-                                                  monthly_housing_benefit: 833.33)
           end
         end
 
         context "with housing benefit as a state_benefit" do
           let(:housing_benefit_amount) { 500.00 }
-
-          before do
-            create :state_benefit, :with_monthly_payments,
-                   payment_amount: housing_benefit_amount,
-                   gross_income_summary: assessment.applicant_gross_income_summary, state_benefit_type: housing_benefit_type
-          end
 
           context "board and lodging" do
             let(:housing_cost_type) { "board_and_lodging" }
@@ -287,19 +171,7 @@ module Calculators
             it "records half the monthly outgoing less the housing benefit" do
               expect(calculator)
                 .to have_attributes(gross_housing_costs: 600.00,
-                                    monthly_housing_benefit: 100.000,
-                                    net_housing_costs: (housing_cost_amount.to_d - housing_benefit_amount.to_d) / 2)
-            end
-          end
-
-          context "rent" do
-            let(:housing_cost_type) { "rent" }
-
-            it "records the full monthly housing costs" do
-              expect(calculator)
-                .to have_attributes(gross_housing_costs: 1200.00,
-                                    monthly_housing_benefit: 500.00,
-                                    net_housing_costs: 700.00)
+                                    net_housing_costs: housing_cost_amount.to_d / 2 - housing_benefit_amount.to_d)
             end
           end
 
@@ -309,138 +181,8 @@ module Calculators
             it "records the full housing costs less the housing benefit" do
               expect(calculator)
                 .to have_attributes(gross_housing_costs: 1200.00,
-                                    monthly_housing_benefit: 500.0,
                                     net_housing_costs: 700.00)
             end
-          end
-        end
-      end
-    end
-
-    context "when using regular_transactions" do
-      let(:instance) do
-        described_class.call(housing_cost_outgoings:,
-                             gross_income_summary: assessment.applicant_gross_income_summary,
-                             housing_costs_cap_applies: dependants.none?,
-                             submission_date: assessment.submission_date)
-      end
-      let(:assessment) { create :assessment, :with_gross_income_summary, :with_disposable_income_summary }
-      let(:dates) { [Date.current, 1.month.ago, 2.months.ago] }
-
-      describe "#gross_housing_costs" do
-        subject(:gross_housing_costs) { instance.gross_housing_costs }
-
-        context "with no housing costs" do
-          let(:dependants) { [] }
-          let(:housing_cost_outgoings) { [] }
-
-          it { is_expected.to eq 0 }
-        end
-
-        context "with all forms of housing costs" do
-          let(:dependants) { [] }
-          let(:housing_cost_outgoings) do
-            # add monthly equivalent bank transactions of 111.11
-            build_list(:housing_cost_outgoing, 1, payment_date: dates[0], amount: 333.33)
-          end
-
-          before do
-            # add average cash transactions of 111.11
-            rent_or_mortgage = create(:rent_or_mortgage_transaction_category, gross_income_summary: assessment.applicant_gross_income_summary)
-            create(:cash_transaction, cash_transaction_category: rent_or_mortgage, date: dates[0], amount: 111.11)
-            create(:cash_transaction, cash_transaction_category: rent_or_mortgage, date: dates[1], amount: 111.11)
-            create(:cash_transaction, cash_transaction_category: rent_or_mortgage, date: dates[2], amount: 111.11)
-
-            # add monthly equivalent regular transaction of 333.33
-            create(:housing_cost, gross_income_summary: assessment.applicant_gross_income_summary, frequency: "three_monthly", amount: 1000.00)
-          end
-
-          # NOTE: expected API use cases should not add both bank and regular transactions
-          it "sums monthly bank, regular and cash transactions" do
-            expect(gross_housing_costs).to eq 555.55 # 111.11 + 111.11 + 333.33
-          end
-        end
-      end
-
-      describe "#monthly_housing_benefit" do
-        subject(:monthly_housing_benefit) { instance.monthly_housing_benefit }
-        let(:housing_cost_outgoings) { [] }
-
-        context "with state_benefits of housing_benefit type" do
-          let(:dependants) { [] }
-
-          before do
-            create(:state_benefit,
-                   state_benefit_type: build(:state_benefit_type, label: "housing_benefit"),
-                   gross_income_summary: assessment.applicant_gross_income_summary,
-                   state_benefit_payments: [
-                     build(:state_benefit_payment, amount: 222.22, payment_date: dates[0]),
-                     build(:state_benefit_payment, amount: 222.22, payment_date: dates[2]),
-                   ])
-          end
-
-          it "returns monthly equivalent" do
-            expect(monthly_housing_benefit).to eq 148.15 # (222.22 + 222.22) / 3
-          end
-        end
-
-        context "with regular_transactions of housing_benefit type" do
-          let(:dependants) { [] }
-
-          before do
-            create(:housing_benefit_regular, gross_income_summary: assessment.applicant_gross_income_summary, frequency: "three_monthly", amount: 1000.00)
-          end
-
-          it "returns monthly equivalent" do
-            expect(monthly_housing_benefit).to eq 333.33 # 1000.00 / 3
-          end
-        end
-      end
-
-      describe "#net_housing_costs" do
-        subject(:net_housing_costs) { instance.net_housing_costs }
-        let(:housing_cost_outgoings) { [] }
-
-        context "when single, with no dependants" do
-          let(:dependants) { [] }
-
-          it "returns gross housing cost less benefits" do
-            create(:housing_cost, gross_income_summary: assessment.applicant_gross_income_summary, frequency: "monthly", amount: 1000.00)
-            create(:housing_benefit_regular, gross_income_summary: assessment.applicant_gross_income_summary, frequency: "monthly", amount: 500.00)
-
-            expect(net_housing_costs).to eq 500.00
-          end
-
-          it "implements a cap" do
-            create(:housing_cost, gross_income_summary: assessment.applicant_gross_income_summary, frequency: "monthly", amount: 1000.00)
-            create(:housing_benefit_regular, gross_income_summary: assessment.applicant_gross_income_summary, frequency: "monthly", amount: 400.00)
-
-            expect(net_housing_costs).to eq 545.00
-          end
-        end
-
-        context "when has dependants and receives housing benefit" do
-          let(:dependants) { build_list(:dependant, 1, :child_relative, submission_date: assessment.submission_date) }
-
-          it "returns gross housing cost less benefits" do
-            create(:housing_cost, gross_income_summary: assessment.applicant_gross_income_summary, frequency: "monthly", amount: 1000.00)
-            create(:housing_benefit_regular, gross_income_summary: assessment.applicant_gross_income_summary, frequency: "monthly", amount: 500.00)
-
-            expect(net_housing_costs).to eq 500.00
-          end
-        end
-
-        # NOTE: when has dependants without benefits
-        # or when not single and with no dependants??
-        #
-        context "when any other situation" do
-          let(:dependants) { build_list(:dependant, 1, :child_relative, submission_date: assessment.submission_date) }
-
-          it "returns gross housing without a cap" do
-            create(:housing_cost, gross_income_summary: assessment.applicant_gross_income_summary, frequency: "monthly", amount: 1000.00)
-            create(:housing_benefit_regular, gross_income_summary: assessment.applicant_gross_income_summary, frequency: "monthly", amount: 400.00)
-
-            expect(net_housing_costs).to eq 600.00
           end
         end
       end

--- a/spec/services/collators/housing_costs_collator_spec.rb
+++ b/spec/services/collators/housing_costs_collator_spec.rb
@@ -2,19 +2,54 @@ require "rails_helper"
 
 module Collators
   RSpec.describe HousingCostsCollator, :calls_bank_holiday do
-    describe ".call" do
-      let(:assessment) { create :assessment, :with_disposable_income_summary, :with_gross_income_summary }
-      let(:disposable_income_summary) { assessment.applicant_disposable_income_summary }
-      let(:gross_income_summary) { assessment.applicant_gross_income_summary }
+    let(:assessment) { create :assessment, :with_disposable_income_summary, :with_gross_income_summary }
+    let(:disposable_income_summary) { assessment.applicant_disposable_income_summary }
+    let(:gross_income_summary) { assessment.applicant_gross_income_summary }
+    let(:housing_benefit_type) { create :state_benefit_type, label: "housing_benefit" }
+    let(:submission_date) { assessment.submission_date }
+    let(:rent_or_mortgage_category) { create(:rent_or_mortgage_transaction_category, gross_income_summary: assessment.applicant_gross_income_summary) }
 
-      subject(:collator) do
-        described_class.call(housing_cost_outgoings:,
-                             person: instance_double(PersonWrapper, single?: true, dependants: []),
-                             gross_income_summary: assessment.applicant_gross_income_summary,
-                             submission_date: assessment.submission_date,
-                             allow_negative_net: false)
+    subject(:collator) do
+      described_class.call(housing_cost_outgoings:,
+                           person: instance_double(PersonWrapper, single?: true, dependants: []),
+                           gross_income_summary: assessment.applicant_gross_income_summary,
+                           submission_date: assessment.submission_date,
+                           allow_negative_net: false)
+    end
+
+    describe "#housing_benefit" do
+      subject(:housing_benefit) { collator.housing_benefit }
+      let(:dates) { [Date.current, 1.month.ago, 2.months.ago] }
+      let(:housing_cost_outgoings) { [] }
+
+      context "with state_benefits of housing_benefit type" do
+        before do
+          create(:state_benefit,
+                 state_benefit_type: build(:state_benefit_type, label: "housing_benefit"),
+                 gross_income_summary: assessment.applicant_gross_income_summary,
+                 state_benefit_payments: [
+                   build(:state_benefit_payment, amount: 222.22, payment_date: dates[0]),
+                   build(:state_benefit_payment, amount: 222.22, payment_date: dates[2]),
+                 ])
+        end
+
+        it "returns monthly equivalent" do
+          expect(housing_benefit).to eq 148.15 # (222.22 + 222.22) / 3
+        end
       end
 
+      context "with regular_transactions of housing_benefit type" do
+        before do
+          create(:housing_benefit_regular, gross_income_summary: assessment.applicant_gross_income_summary, frequency: "three_monthly", amount: 1000.00)
+        end
+
+        it "returns monthly equivalent" do
+          expect(housing_benefit).to eq 333.33 # 1000.00 / 3
+        end
+      end
+    end
+
+    describe ".call" do
       context "with no housing cost outgoings" do
         let(:housing_cost_outgoings) { [] }
 
@@ -32,7 +67,6 @@ module Collators
 
         context "with housing benefit as a state_benefit" do
           before do
-            housing_benefit_type = create :state_benefit_type, label: "housing_benefit"
             state_benefit = create :state_benefit, gross_income_summary:, state_benefit_type: housing_benefit_type
             create :state_benefit_payment, state_benefit:, amount: 101.02, payment_date: Date.current
             create :state_benefit_payment, state_benefit:, amount: 101.02, payment_date: 1.month.ago
@@ -87,7 +121,6 @@ module Collators
 
         context "with housing benefit as a state_benefit" do
           before do
-            housing_benefit_type = create :state_benefit_type, label: "housing_benefit"
             state_benefit = create :state_benefit, gross_income_summary:, state_benefit_type: housing_benefit_type
             create :state_benefit_payment, state_benefit:, amount: 101.02, payment_date: Date.current
             create :state_benefit_payment, state_benefit:, amount: 101.02, payment_date: 1.month.ago
@@ -118,6 +151,22 @@ module Collators
                   net_housing_costs: 254.42, # 355.44 - 101.02
                 )
             end
+          end
+        end
+
+        context "with weekly housing benefit" do
+          let(:housing_benefit_amount) { 500.00 }
+          let(:housing_cost_type) { "rent" }
+          let(:state_benefit) { create :state_benefit, gross_income_summary: assessment.applicant_gross_income_summary, state_benefit_type: housing_benefit_type }
+
+          before do
+            [submission_date - 4.weeks, submission_date - 3.weeks, submission_date - 2.weeks, submission_date - 1.week, submission_date].each do |pay_date|
+              create :state_benefit_payment, state_benefit:, amount: housing_benefit_amount, payment_date: pay_date
+            end
+          end
+
+          it "records the full monthly housing costs" do
+            expect(collator).to have_attributes(gross_housing_costs: 355.44, housing_benefit: 833.33)
           end
         end
       end
@@ -153,6 +202,20 @@ module Collators
                 net_housing_costs: 0.00,
               )
           end
+        end
+      end
+
+      context "with cash payments" do
+        let(:housing_cost_outgoings) { [] }
+
+        before do
+          create(:cash_transaction, cash_transaction_category: rent_or_mortgage_category, amount: 564)
+        end
+
+        it "caps the net costs" do
+          expect(collator)
+            .to have_attributes(gross_housing_costs: 564.00,
+                                net_housing_costs: 545.00) # Cap applied
         end
       end
     end

--- a/spec/services/collators/regular_outgoings_collator_spec.rb
+++ b/spec/services/collators/regular_outgoings_collator_spec.rb
@@ -74,21 +74,6 @@ RSpec.describe Collators::RegularOutgoingsCollator do
       end
     end
 
-    # ** see above for reason
-    context "with monthly regular transactions of :rent_or_mortgage" do
-      before do
-        create(:regular_transaction, gross_income_summary:, operation: "debit", category: "rent_or_mortgage", frequency: "monthly", amount: 222.22)
-      end
-
-      it "increments #rent_or_mortgage_all_sources data" do
-        expect(collator).to have_attributes(
-          rent_or_mortgage_regular: 222.22,
-          legal_aid_regular: 0.00,
-          maintenance_out_regular: 0.0,
-        )
-      end
-    end
-
     context "with monthly regular transaction of :child_care" do
       before do
         create(:regular_transaction,


### PR DESCRIPTION
No ticket - supporting 2 MTR Phase 2 housing benefit tickets

Rework HousingCostCollator and HousingCostCalculator - the collator now 'collates' (mostly) and all housing costs now come through this route rather than the side-routes of regular and cash transactions (as the data need to be halved when board and lodging is in effect).

---

## Checklists

Author: (before you ask people to review this PR)

- [x] Diff - review it, ensuring it contains only expected changes
- [x] Whitespace changes - avoid if possible, because they make diffs harder to read and conflicts more likely
- [x] Changelog - add a line, if it meets the criteria
- [x] Secrets - no secrets should be added
- [x] Commit messages - say *why* the change was made
- [x] PR description - summarizes *what* changed and *why*, with a JIRA ticket ID
- [x] Tests pass - on CircleCI
- [x] Conflicts - resolve if Github reports them. e.g. with `git rebase main`

Reviewers remember:

- [ ] Jira ticket criteria are met
- [ ] Migrations - test migration and rollback: `rake db:migrate && rake db:rollback`
