### PR TITLE
LEP-232 disposable income lower === top of zero contribution band

### DIFF
--- a/app/services/creators/disposable_income_eligibility_creator.rb
+++ b/app/services/creators/disposable_income_eligibility_creator.rb
@@ -6,7 +6,9 @@ module Creators
           Eligibility::DisposableIncome.new(proceeding_type: e.proceeding_type,
                                             upper_threshold: e.upper_threshold,
                                             lower_threshold: e.lower_threshold,
-                                            assessment_result: assessment_result(lower_threshold: e.lower_threshold, upper_threshold: e.upper_threshold, total_disposable_income:))
+                                            assessment_result: assessment_result(lower_threshold: e.lower_threshold,
+                                                                                 upper_threshold: e.upper_threshold,
+                                                                                 total_disposable_income:))
         end
       end
 

--- a/config/thresholds/mtr-2026.yml
+++ b/config/thresholds/mtr-2026.yml
@@ -5,7 +5,7 @@ infinite_gross_income_upper: 999_999_999_999
 gross_income:
   dependant_over_14_increase_percent: 50
   dependant_under_14_increase_percent: 30
-disposable_income_lower_certificated: 315
+disposable_income_lower_certificated: 622
 disposable_income_lower_controlled: 946
 disposable_income_upper: 946
 capital_lower_certificated: 7_000

--- a/features/mtr/immigration_and_asylum.feature
+++ b/features/mtr/immigration_and_asylum.feature
@@ -11,7 +11,7 @@ Feature:
       | capital_lower_threshold      | 7000.0  |
       | capital_upper_threshold      | 11000.0 |
       | disposable_upper_threshold   | 946.0   |
-      | disposable_lower_threshold   | 315.0   |
+      | disposable_lower_threshold   | 622.0   |
 
   Scenario: Immigration case after MTR
     Given I am undertaking a certificated assessment
@@ -23,7 +23,7 @@ Feature:
       | capital_lower_threshold      | 7000.0  |
       | capital_upper_threshold      | 11000.0 |
       | disposable_upper_threshold   | 946.0   |
-      | disposable_lower_threshold   | 315.0   |
+      | disposable_lower_threshold   | 622.0   |
 
   Scenario: Immigration controller case after MTR
     Given I am undertaking a controlled assessment

--- a/features/mtr/income_capital_thresholds.feature
+++ b/features/mtr/income_capital_thresholds.feature
@@ -32,7 +32,7 @@ Feature:
     Then I should see the following overall summary:
       | attribute                      | value    |
       | assessment_result              | eligible |
-      | disposable_lower_threshold     | 315.0    |
+      | disposable_lower_threshold     | 622.0    |
       | disposable_upper_threshold     | 946.0    |
     And I should see the following "disposable_income_summary" details:
       | attribute                      | value    |
@@ -48,7 +48,7 @@ Feature:
       | attribute                      | value                 |
       | assessment_result              | contribution_required |
       | gross_income_upper_threshold_0 |       2912.5          |
-      | disposable_lower_threshold     |        315.0          |
+      | disposable_lower_threshold     |        622.0          |
       | disposable_upper_threshold     |        946.0          |
     And I should see the following "disposable_income_summary" details:
       | attribute                      | value    |
@@ -86,7 +86,7 @@ Feature:
     Then I should see the following overall summary:
       | attribute                      | value                 |
       | assessment_result              | contribution_required |
-      | disposable_lower_threshold     | 315.0                 |
+      | disposable_lower_threshold     | 622.0                 |
       | disposable_upper_threshold     | 946.0                 |
       | capital_lower_threshold        | 7000.0                |
       | capital_upper_threshold        | 11000.0               |

--- a/spec/services/creators/disposable_income_eligibility_creator_spec.rb
+++ b/spec/services/creators/disposable_income_eligibility_creator_spec.rb
@@ -71,7 +71,7 @@ module Creators
 
       it "no longer applies a special threshold for immigration proceedings" do
         elig = creator.detect { |p| p.proceeding_type.ccms_code == "IM030" }
-        expect(elig).to have_attributes(upper_threshold: 733.0, lower_threshold: 315.0)
+        expect(elig).to have_attributes(upper_threshold: 733.0, lower_threshold: 622.0)
       end
     end
   end


### PR DESCRIPTION
https://dsdmoj.atlassian.net/browse/LEP-232

Increase disposable income lower threshold for MTR. We already have a 'lower contribution band' figure, and this threshold is the same value (its the value at which contributions start)

---

## Checklists

Author: (before you ask people to review this PR)

- [x] Diff - review it, ensuring it contains only expected changes
- [x] Whitespace changes - avoid if possible, because they make diffs harder to read and conflicts more likely
- [x] Changelog - add a line, if it meets the criteria
- [x] Secrets - no secrets should be added
- [x] Commit messages - say *why* the change was made
- [x] PR description - summarizes *what* changed and *why*, with a JIRA ticket ID
- [x] Tests pass - on CircleCI
- [x] Conflicts - resolve if Github reports them. e.g. with `git rebase main`

Reviewers remember:

- [ ] Jira ticket criteria are met
- [ ] Migrations - test migration and rollback: `rake db:migrate && rake db:rollback`
