### PR TITLE
Dockerfile updated to Alpine 3.18 and cosmetic improvements

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -42,9 +42,10 @@ COPY . /myapp
 WORKDIR /myapp
 
 # Run and own only the runtime files as a non-root user for security
-RUN adduser --disabled-password rails && \
+RUN adduser --disabled-password rails -u 1001 && \
     chown -R rails:rails /myapp
-USER rails:rails
+# (Numeric user needs to be used to show that it's non-root)
+USER 1001
 
 # expect ping environment variables
 ARG BUILD_DATE


### PR DESCRIPTION
Upgrade from Alpine 3.17 to [3.18](https://alpinelinux.org/releases/) moves us to the latest minor release. No particular driver for this, apart from staying on top of things.

The other changes are cosmetic, but brings us closer to a Kamal-generated Dockerfile:
https://greg.molnar.io/blog/deploying-a-rails-app-with-kamal/
Kamal seems to be what's [now the default style built into Rails 7.1](https://edgeguides.rubyonrails.org/7_1_release_notes.html#generate-dockerfiles-for-new-rails-applications) so I think it's good to be in line with this.

I've deviated from Kamal in a couple of ways:
* Stick with alpine, as its much smaller than debian (I've added comments)
* Use a numeric user, which is required by Cloud Platform since it runs containers as non-root (I've added a comment)
* Not tackled the bootsnap pre-compile thing at this point - we could still try it in future

I've tested on UAT deployed version:
<img width="944" alt="Screenshot 2023-10-12 at 10 53 02" src="https://github.com/ministryofjustice/cfe-civil/assets/307612/2d510d28-c4bc-4906-a5a5-df7be5a5ebea">

No ticket

---

## Checklists

Author: (before you ask people to review this PR)

- [x] Diff - review it, ensuring it contains only expected changes
- [x] Whitespace changes - avoid if possible, because they make diffs harder to read and conflicts more likely
- [ ] Changelog - add a line, if it meets the criteria
- [x] Secrets - no secrets should be added
- [x] Commit messages - say *why* the change was made
- [x] PR description - summarizes *what* changed and *why*, with a JIRA ticket ID
- [x] Tests pass - on CircleCI
- [x] Conflicts - resolve if Github reports them. e.g. with `git rebase main`

Reviewers remember:

- [ ] Jira ticket criteria are met
- [ ] Migrations - test migration and rollback: `rake db:migrate && rake db:rollback`
