### PR TITLE
LEP-345 move applicant flags out of calculation output object

### DIFF
--- a/app/lib/calculation_output.rb
+++ b/app/lib/calculation_output.rb
@@ -2,25 +2,19 @@ class CalculationOutput
   delegate :income_contribution, :applicant_disposable_income_subtotals, :partner_disposable_income_subtotals,
            :combined_total_disposable_income, :combined_total_outgoings_and_allowances, to: :@disposable_income_subtotals
 
-  # The receives_qualifying_benefit:, receives_asylum_support: parameters are temporary whilst we refactor
-  # the eligibilities objects. Once this is complete these parameters should be able to be be removed
-  def initialize(gross_income_subtotals:, disposable_income_subtotals:, capital_subtotals:,
-                 receives_qualifying_benefit:, receives_asylum_support:, submission_date:)
+  def initialize(gross_income_subtotals:, disposable_income_subtotals:, capital_subtotals:)
     @gross_income_subtotals = gross_income_subtotals
     @disposable_income_subtotals = disposable_income_subtotals
     @capital_subtotals = capital_subtotals
-    @receives_qualifying_benefit = receives_qualifying_benefit
-    @receives_asylum_support = receives_asylum_support
-    @submission_date = submission_date
   end
 
-  attr_reader :capital_subtotals, :gross_income_subtotals, :receives_qualifying_benefit, :receives_asylum_support, :submission_date
+  attr_reader :capital_subtotals, :gross_income_subtotals
 
   def disposable_income_eligibilities(proceeding_types)
     @disposable_income_subtotals.eligibilities proceeding_types
   end
 
-  def assessment_results(proceeding_types)
+  def assessment_results(proceeding_types:, receives_qualifying_benefit:, receives_asylum_support:, submission_date:)
     @assessment_results ||= Summarizers::MainSummarizer.assessment_results(proceeding_types:,
                                                                            receives_qualifying_benefit:,
                                                                            receives_asylum_support:,
@@ -30,7 +24,7 @@ class CalculationOutput
                                                                            capital_assessment_results: @capital_subtotals.assessment_results(proceeding_types))
   end
 
-  def summarized_assessment_result(proceeding_types)
-    Utilities::ResultSummarizer.call(assessment_results(proceeding_types).values).to_s
+  def summarized_assessment_result(proceeding_types:, receives_qualifying_benefit:, receives_asylum_support:, submission_date:)
+    Utilities::ResultSummarizer.call(assessment_results(proceeding_types:, receives_qualifying_benefit:, receives_asylum_support:, submission_date:).values).to_s
   end
 end

--- a/app/services/decorators/v6/assessment_decorator.rb
+++ b/app/services/decorators/v6/assessment_decorator.rb
@@ -16,7 +16,11 @@ module Decorators
           version: @version,
           timestamp: Time.current,
           success: true,
-          result_summary: ResultSummaryDecorator.new(assessment, @calculation_output, @partner.present?).as_json,
+          result_summary: ResultSummaryDecorator.new(assessment:, calculation_output: @calculation_output,
+                                                     receives_asylum_support: @applicant.details.receives_asylum_support,
+                                                     receives_qualifying_benefit: @applicant.details.receives_qualifying_benefit,
+                                                     submission_date: assessment.submission_date,
+                                                     partner_present: @partner.present?).as_json,
           assessment: assessment_details.transform_values(&:as_json),
         }
       end
@@ -24,6 +28,10 @@ module Decorators
     private
 
       def assessment_details
+        summarized_assessment_result = @calculation_output.summarized_assessment_result(proceeding_types: assessment.proceeding_types,
+                                                                                        submission_date: assessment.submission_date,
+                                                                                        receives_asylum_support: @applicant.details.receives_asylum_support,
+                                                                                        receives_qualifying_benefit: @applicant.details.receives_qualifying_benefit)
         details = {
           id: assessment.id,
           client_reference_id: assessment.client_reference_id,
@@ -38,7 +46,7 @@ module Decorators
           ),
           capital: CapitalDecorator.new(assessment.applicant_capital_summary,
                                         @calculation_output.capital_subtotals.applicant_capital_subtotals),
-          remarks: RemarksDecorator.new(assessment.remarks, @calculation_output.summarized_assessment_result(assessment.proceeding_types)),
+          remarks: RemarksDecorator.new(assessment.remarks, summarized_assessment_result),
         }
         if @partner.present?
           details.merge(partner_gross_income:, partner_disposable_income:, partner_capital:)

--- a/app/services/decorators/v6/result_summary_decorator.rb
+++ b/app/services/decorators/v6/result_summary_decorator.rb
@@ -3,17 +3,23 @@ module Decorators
     class ResultSummaryDecorator
       attr_reader :assessment
 
-      def initialize(assessment, calculation_output, partner_present)
+      def initialize(assessment:, calculation_output:, partner_present:, receives_qualifying_benefit:, receives_asylum_support:, submission_date:)
         @assessment = assessment
         @calculation_output = calculation_output
         @partner_present = partner_present
+        @receives_qualifying_benefit = receives_qualifying_benefit
+        @receives_asylum_support =   receives_asylum_support
+        @submission_date = submission_date
       end
 
       def as_json
         capital_contribution = @calculation_output.capital_subtotals.capital_contribution(assessment.proceeding_types).to_f
         income_contribution = @calculation_output.income_contribution(assessment.proceeding_types)
 
-        assessment_results = @calculation_output.assessment_results(assessment.proceeding_types).map do |proceeding_type, result|
+        assessment_results = @calculation_output.assessment_results(proceeding_types: assessment.proceeding_types,
+                                                                    submission_date: @submission_date,
+                                                                    receives_qualifying_benefit: @receives_qualifying_benefit,
+                                                                    receives_asylum_support: @receives_asylum_support).map do |proceeding_type, result|
           {
             ccms_code: proceeding_type.ccms_code,
             upper_threshold: 0.0,
@@ -26,7 +32,10 @@ module Decorators
 
         details = {
           overall_result: {
-            result: @calculation_output.summarized_assessment_result(assessment.proceeding_types),
+            result: @calculation_output.summarized_assessment_result(proceeding_types: assessment.proceeding_types,
+                                                                     submission_date: @submission_date,
+                                                                     receives_qualifying_benefit: @receives_qualifying_benefit,
+                                                                     receives_asylum_support: @receives_asylum_support),
             capital_contribution:,
             income_contribution:,
             proceeding_types: assessment_results.as_json,

--- a/app/services/workflows/main_workflow.rb
+++ b/app/services/workflows/main_workflow.rb
@@ -8,9 +8,7 @@ module Workflows
                                blank_calculation_result(submission_date: assessment.submission_date,
                                                         level_of_help: assessment.level_of_help,
                                                         applicant_capitals: applicant.capitals_data,
-                                                        partner_capitals: partner&.capitals_data,
-                                                        receives_qualifying_benefit: applicant.details.receives_qualifying_benefit,
-                                                        receives_asylum_support: applicant.details.receives_asylum_support)
+                                                        partner_capitals: partner&.capitals_data)
                              elsif applicant.details.receives_qualifying_benefit?
                                if partner.present?
                                  PassportedWorkflow.partner(capitals_data: applicant.capitals_data,
@@ -18,14 +16,12 @@ module Workflows
                                                             date_of_birth: applicant.details.date_of_birth,
                                                             level_of_help: assessment.level_of_help,
                                                             submission_date: assessment.submission_date,
-                                                            partner_date_of_birth: partner.details.date_of_birth,
-                                                            receives_asylum_support: applicant.details.receives_asylum_support)
+                                                            partner_date_of_birth: partner.details.date_of_birth)
                                else
                                  PassportedWorkflow.call(capitals_data: applicant.capitals_data,
                                                          date_of_birth: applicant.details.date_of_birth,
                                                          submission_date: assessment.submission_date,
-                                                         level_of_help: assessment.level_of_help,
-                                                         receives_asylum_support: applicant.details.receives_asylum_support)
+                                                         level_of_help: assessment.level_of_help)
                                end
                              else
                                result = NonPassportedWorkflow.call(assessment:, applicant:, partner:)
@@ -61,13 +57,11 @@ module Workflows
 
     private
 
-      def blank_calculation_result(applicant_capitals:, partner_capitals:, level_of_help:, submission_date:,
-                                   receives_qualifying_benefit:, receives_asylum_support:)
+      def blank_calculation_result(applicant_capitals:, partner_capitals:, level_of_help:, submission_date:)
         CalculationOutput.new(
-          receives_qualifying_benefit:, receives_asylum_support:, submission_date:,
           gross_income_subtotals: GrossIncome::Unassessed.new,
           disposable_income_subtotals: DisposableIncome::Unassessed.new(level_of_help:, submission_date:),
-          capital_subtotals: Capital::Unassessed.new(applicant_capitals:, partner_capitals:, submission_date:, level_of_help:)
+          capital_subtotals: Capital::Unassessed.new(applicant_capitals:, partner_capitals:, submission_date:, level_of_help:),
         )
       end
     end

--- a/app/services/workflows/non_passported_workflow.rb
+++ b/app/services/workflows/non_passported_workflow.rb
@@ -9,9 +9,6 @@ module Workflows
 
         calculation_output = if gross_income_subtotals.gross.ineligible? assessment.proceeding_types
                                CalculationOutput.new(gross_income_subtotals: gross_income_subtotals.gross,
-                                                     receives_qualifying_benefit: applicant.details.receives_qualifying_benefit,
-                                                     receives_asylum_support: applicant.details.receives_asylum_support,
-                                                     submission_date: assessment.submission_date,
                                                      disposable_income_subtotals: unassessed_disposable_income(assessment:),
                                                      capital_subtotals: unassessed_capital)
                              else
@@ -19,16 +16,10 @@ module Workflows
                                if disposable_income_subtotals.ineligible? assessment.proceeding_types
                                  CalculationOutput.new(gross_income_subtotals: gross_income_subtotals.gross,
                                                        disposable_income_subtotals:,
-                                                       capital_subtotals: unassessed_capital,
-                                                       receives_qualifying_benefit: applicant.details.receives_qualifying_benefit,
-                                                       receives_asylum_support: applicant.details.receives_asylum_support,
-                                                       submission_date: assessment.submission_date)
+                                                       capital_subtotals: unassessed_capital)
                                else
                                  capital_subtotals = get_capital_subtotals(assessment:, applicant:, partner:, disposable_income_subtotals:)
-                                 CalculationOutput.new(gross_income_subtotals: gross_income_subtotals.gross, disposable_income_subtotals:, capital_subtotals:,
-                                                       receives_qualifying_benefit: applicant.details.receives_qualifying_benefit,
-                                                       receives_asylum_support: applicant.details.receives_asylum_support,
-                                                       submission_date: assessment.submission_date)
+                                 CalculationOutput.new(gross_income_subtotals: gross_income_subtotals.gross, disposable_income_subtotals:, capital_subtotals:)
                                end
                              end
 

--- a/app/services/workflows/passported_workflow.rb
+++ b/app/services/workflows/passported_workflow.rb
@@ -1,22 +1,20 @@
 module Workflows
   class PassportedWorkflow
     class << self
-      def call(capitals_data:, date_of_birth:, receives_asylum_support:, submission_date:, level_of_help:)
+      def call(capitals_data:, date_of_birth:, submission_date:, level_of_help:)
         capital_subtotals = CapitalCollatorAndAssessor.passported(capitals_data:, submission_date:, level_of_help:,
                                                                   date_of_birth:)
-        CalculationOutput.new(receives_qualifying_benefit: true, receives_asylum_support:, submission_date:,
-                              capital_subtotals:,
+        CalculationOutput.new(capital_subtotals:,
                               disposable_income_subtotals: DisposableIncome::Unassessed.new(submission_date:, level_of_help:),
                               gross_income_subtotals: GrossIncome::Unassessed.new)
       end
 
       def partner(capitals_data:, partner_capitals_data:, date_of_birth:,
-                  partner_date_of_birth:, receives_asylum_support:,
+                  partner_date_of_birth:,
                   submission_date:, level_of_help:)
         capital_subtotals = CapitalCollatorAndAssessor.partner_passported(capitals_data:, partner_capitals_data:, date_of_birth:,
                                                                           partner_date_of_birth:, submission_date:, level_of_help:)
-        CalculationOutput.new(receives_qualifying_benefit: true, receives_asylum_support:, submission_date:,
-                              capital_subtotals:,
+        CalculationOutput.new(capital_subtotals:,
                               disposable_income_subtotals: DisposableIncome::Unassessed.new(submission_date:, level_of_help:),
                               gross_income_subtotals: GrossIncome::Unassessed.new)
       end

--- a/spec/services/workflows/main_workflow_spec.rb
+++ b/spec/services/workflows/main_workflow_spec.rb
@@ -90,8 +90,7 @@ module Workflows
                                                                                            non_liquid_capital_items: [], main_home: {}, additional_properties: []),
                                                            date_of_birth: applicant.date_of_birth,
                                                            submission_date: assessment.submission_date,
-                                                           level_of_help: assessment.level_of_help,
-                                                           receives_asylum_support: false).and_return(calculation_output)
+                                                           level_of_help: assessment.level_of_help).and_return(calculation_output)
           workflow_call
         end
 
@@ -124,8 +123,7 @@ module Workflows
                                                                partner_date_of_birth: partner.date_of_birth,
                                                                date_of_birth: applicant.date_of_birth,
                                                                level_of_help: assessment.level_of_help,
-                                                               submission_date: assessment.submission_date,
-                                                               receives_asylum_support: false).and_call_original
+                                                               submission_date: assessment.submission_date).and_call_original
           workflow_call
         end
       end

--- a/spec/services/workflows/non_passported_workflow_spec.rb
+++ b/spec/services/workflows/non_passported_workflow_spec.rb
@@ -98,7 +98,10 @@ module Workflows
         co = described_class.call(assessment:,
                                   applicant: build(:person_data, details: applicant, dependants:, employments:, capitals_data: build(:capitals_data, main_home:, additional_properties:)),
                                   partner: partner.present? ? build(:person_data, details: partner, employments: partner_employments, capitals_data: build(:capitals_data, main_home: partner_main_home, additional_properties: partner_additional_properties)) : nil)
-        co.calculation_output.summarized_assessment_result(assessment.proceeding_types)
+        co.calculation_output.summarized_assessment_result(proceeding_types: assessment.proceeding_types,
+                                                           submission_date: assessment.submission_date,
+                                                           receives_qualifying_benefit: applicant.receives_qualifying_benefit,
+                                                           receives_asylum_support: applicant.receives_asylum_support)
       end
 
       context "with controlled work" do

--- a/spec/services/workflows/passported_workflow_spec.rb
+++ b/spec/services/workflows/passported_workflow_spec.rb
@@ -21,8 +21,7 @@ module Workflows
         described_class.call(capitals_data: CapitalsData.new(vehicles: [], liquid_capital_items: [], non_liquid_capital_items: [], main_home: nil, additional_properties: []),
                              date_of_birth: applicant.date_of_birth,
                              submission_date: assessment.submission_date,
-                             level_of_help: assessment.level_of_help,
-                             receives_asylum_support: applicant.receives_asylum_support)
+                             level_of_help: assessment.level_of_help)
       end
 
       it "calls Capital collator and return some data" do


### PR DESCRIPTION
https://dsdmoj.atlassian.net/browse/LEP-345

move receives_asylum_support and receives_qualifying_benefit out of calculation output

---

## Checklists

Author: (before you ask people to review this PR)

- [x] Diff - review it, ensuring it contains only expected changes
- [x] Whitespace changes - avoid if possible, because they make diffs harder to read and conflicts more likely
- [ ] Changelog - add a line, if it meets the criteria
- [ ] Secrets - no secrets should be added
- [x] Commit messages - say *why* the change was made
- [x] PR description - summarizes *what* changed and *why*, with a JIRA ticket ID
- [x] Tests pass - on CircleCI
- [x] Conflicts - resolve if Github reports them. e.g. with `git rebase main`

Reviewers remember:

- [ ] Jira ticket criteria are met
- [ ] Migrations - test migration and rollback: `rake db:migrate && rake db:rollback`
