### PR TITLE
fix flakey cash transactions spec by using match_array

### DIFF
--- a/spec/models/cash_transaction_spec.rb
+++ b/spec/models/cash_transaction_spec.rb
@@ -10,11 +10,11 @@ describe CashTransaction do
 
   describe "by_operation_and_category" do
     it "display all the cash transactions for benefits 1" do
-      expect(assessment1.applicant_gross_income_summary.cash_transactions.by_operation_and_category(:credit, :benefits)).to eq benefits_transactions1
+      expect(assessment1.applicant_gross_income_summary.cash_transactions.by_operation_and_category(:credit, :benefits)).to match_array benefits_transactions1
     end
 
     it "display all the cash transactions for benefits 2" do
-      expect(assessment2.applicant_gross_income_summary.cash_transactions.by_operation_and_category(:credit, :benefits)).to eq benefits_transactions2
+      expect(assessment2.applicant_gross_income_summary.cash_transactions.by_operation_and_category(:credit, :benefits)).to match_array benefits_transactions2
     end
   end
 end


### PR DESCRIPTION
No ticket

cas transactions spec is flakey because is uses eq rather than the weaker match_array

---

## Checklists

Author: (before you ask people to review this PR)

- [ ] Diff - review it, ensuring it contains only expected changes
- [ ] Whitespace changes - avoid if possible, because they make diffs harder to read and conflicts more likely
- [ ] Changelog - add a line, if it meets the criteria
- [ ] Secrets - no secrets should be added
- [ ] Commit messages - say *why* the change was made
- [ ] PR description - summarizes *what* changed and *why*, with a JIRA ticket ID
- [ ] Tests pass - on CircleCI
- [ ] Conflicts - resolve if Github reports them. e.g. with `git rebase main`

Reviewers remember:

- [ ] Jira ticket criteria are met
- [ ] Migrations - test migration and rollback: `rake db:migrate && rake db:rollback`
