### PR TITLE
change lcov location only for CI

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -13,8 +13,10 @@ end
 
 SimpleCov::Formatter::LcovFormatter.config.report_with_single_file = true
 # for cc-test-reporter after-build action
-SimpleCov::Formatter::LcovFormatter.config.output_directory = "coverage"
-SimpleCov::Formatter::LcovFormatter.config.lcov_file_name = "lcov.info"
+if ENV.key? "CI"
+  SimpleCov::Formatter::LcovFormatter.config.output_directory = "coverage"
+  SimpleCov::Formatter::LcovFormatter.config.lcov_file_name = "lcov.info"
+end
 SimpleCov.formatter = SimpleCov::Formatter::MergedFormatter
 
 unless ENV["NOCOVERAGE"]


### PR DESCRIPTION
No Ticket

This changes the lcov location to only be set for CI - which is true from the comment, but not the code.

---

## Checklists

Author: (before you ask people to review this PR)

- [ ] Diff - review it, ensuring it contains only expected changes
- [ ] Whitespace changes - avoid if possible, because they make diffs harder to read and conflicts more likely
- [ ] Changelog - add a line, if it meets the criteria
- [ ] Secrets - no secrets should be added
- [ ] Commit messages - say *why* the change was made
- [ ] PR description - summarizes *what* changed and *why*, with a JIRA ticket ID
- [ ] Tests pass - on CircleCI
- [ ] Conflicts - resolve if Github reports them. e.g. with `git rebase main`

Reviewers remember:

- [ ] Jira ticket criteria are met
- [ ] Migrations - test migration and rollback: `rake db:migrate && rake db:rollback`
