### PR TITLE
Fix flakey swaggerization check

### DIFF
--- a/lib/tasks/rswag.rake
+++ b/lib/tasks/rswag.rake
@@ -3,16 +3,17 @@ task check_swaggerization: :environment do
   require "digest/sha1"
 
   swagger_root = Rswag::Api.config.swagger_root
-  files = Dir.glob("#{swagger_root}/**/*.yaml")
+  # make sure files are always loaded in the same order
+  files = Dir.glob("#{swagger_root}/**/*.yaml").sort
 
-  current_digests = files.each_with_object([]) do |file, digests|
-    digests << Digest::SHA1.hexdigest(File.read(file))
+  current_digests = files.map do |file|
+    Digest::SHA1.hexdigest(File.read(file))
   end
 
   system("bundle exec rails rswag:specs:swaggerize", %i[err out] => File::NULL)
 
-  new_digests = files.each_with_object([]) do |file, digests|
-    digests << Digest::SHA1.hexdigest(File.read(file))
+  new_digests = files.map do |file|
+    Digest::SHA1.hexdigest(File.read(file))
   end
 
   if new_digests != current_digests


### PR DESCRIPTION
No ticket

This is an attempt to fix the flakey swaggerization check. It looks like it is possible that running the 'glob' twice could result in the files being returned in a different order (very occasionally) which would result in the array comparison failing. This sorts the array (and makes the rake task a bit more idiomatic) to try and prevent this issue recurring

---

## Checklists

Author: (before you ask people to review this PR)

- [ ] Diff - review it, ensuring it contains only expected changes
- [ ] Whitespace changes - avoid if possible, because they make diffs harder to read and conflicts more likely
- [ ] Changelog - add a line, if it meets the criteria
- [ ] Secrets - no secrets should be added
- [ ] Commit messages - say *why* the change was made
- [ ] PR description - summarizes *what* changed and *why*, with a JIRA ticket ID
- [ ] Tests pass - on CircleCI
- [ ] Conflicts - resolve if Github reports them. e.g. with `git rebase main`

Reviewers remember:

- [ ] Jira ticket criteria are met
- [ ] Migrations - test migration and rollback: `rake db:migrate && rake db:rollback`
