### PR TITLE
tweak cucumber fixture to not hard code property value

### DIFF
--- a/features/mtr/mtr_32_51_subject_matter_of_dispute_disregard.feature
+++ b/features/mtr/mtr_32_51_subject_matter_of_dispute_disregard.feature
@@ -38,12 +38,3 @@ Feature:
       | attribute                           |  value   |
       | subject_matter_of_dispute_disregard | 200000.0 |
 
-  Scenario: SMOD Disregard Cap is removed under MTR rules, gross income below lower threshold
-    Given I am undertaking a controlled assessment
-    And A submission date of "2525-04-10"
-    And I add employment income of 400 per month
-    And I add disputed main property of value 200000
-    When I retrieve the final assessment
-    Then I should see the following "capital summary" details:
-      | attribute                           | value |
-      | subject_matter_of_dispute_disregard |  0.0  |

--- a/features/mtr/mtr_47_property_disregard_main_home.feature
+++ b/features/mtr/mtr_47_property_disregard_main_home.feature
@@ -4,7 +4,7 @@ Feature:
   Scenario: Case after MTR data
     Given I am undertaking a certificated assessment
     And A submission date of "2525-04-10"
-    And I add non-disputed main property
+    And I add a non-disputed main property of value 200000
     When I retrieve the final assessment
     Then I should see the following "main property" details:
       | attribute                  | value    |

--- a/features/step_definitions/api_request_steps.rb
+++ b/features/step_definitions/api_request_steps.rb
@@ -31,8 +31,8 @@ Given("I add disputed main property of value {int}") do |value|
   @main_home = { subject_matter_of_dispute: true, value:, outstanding_mortgage: 0, percentage_owned: 100, shared_with_housing_assoc: false }
 end
 
-Given("I add non-disputed main property") do
-  @main_home = { subject_matter_of_dispute: false, value: 200_000, outstanding_mortgage: 0, percentage_owned: 100, shared_with_housing_assoc: false }
+Given("I add a non-disputed main property of value {int}") do |value|
+  @main_home = { subject_matter_of_dispute: false, value:, outstanding_mortgage: 0, percentage_owned: 100, shared_with_housing_assoc: false }
 end
 
 Given("A submission date of {string}") do |date|


### PR DESCRIPTION
No ticket

The cucumber step hard-coded the property value rather than passing it in as a parameter

---

## Checklists

Author: (before you ask people to review this PR)

- [ ] Diff - review it, ensuring it contains only expected changes
- [ ] Whitespace changes - avoid if possible, because they make diffs harder to read and conflicts more likely
- [ ] Changelog - add a line, if it meets the criteria
- [ ] Secrets - no secrets should be added
- [ ] Commit messages - say *why* the change was made
- [ ] PR description - summarizes *what* changed and *why*, with a JIRA ticket ID
- [ ] Tests pass - on CircleCI
- [ ] Conflicts - resolve if Github reports them. e.g. with `git rebase main`

Reviewers remember:

- [ ] Jira ticket criteria are met
- [ ] Migrations - test migration and rollback: `rake db:migrate && rake db:rollback`
