### PR TITLE
LEP-407 document and test client involvement types from LFA

### DIFF
--- a/app/constants/cfe_constants.rb
+++ b/app/constants/cfe_constants.rb
@@ -67,10 +67,6 @@ module CFEConstants
   VALID_FREQUENCIES = %i[monthly four_weekly two_weekly weekly unknown].freeze
   NUMBER_OF_MONTHS_TO_AVERAGE = 3
 
-  # client_involvement_types
-  #
-  VALID_CLIENT_INVOLVEMENT_TYPES = %w[A D W Z I].freeze
-
   # Number of days before assessment is considered stale and eligible for deletion
   STALE_ASSESSMENT_THRESHOLD_DAYS = 14
 

--- a/app/lib/swagger_docs.rb
+++ b/app/lib/swagger_docs.rb
@@ -1574,14 +1574,12 @@ class SwaggerDocs
                   ccms_code: {
                     type: :string,
                     enum: CFEConstants::VALID_PROCEEDING_TYPE_CCMS_CODES,
-                    example: "DA001",
                     description: "A proxy for the type of law. Values beginning with DA are considered domestic abuse cases. IM030 indicates an immigration case. IA031 indicates an asylum case.",
                   },
                   client_involvement_type: {
                     type: :string,
-                    enum: CFEConstants::VALID_CLIENT_INVOLVEMENT_TYPES,
-                    example: "A",
-                    description: "A CCMS client_involvement_type. This is not used in the calculation, so can be set to any valid value.",
+                    enum: ProceedingType::VALID_CLIENT_INVOLVEMENT_TYPES,
+                    description: "CCMS Client Involvement type A=applicant/claimant/petitioner, D=Defendant, W=subject of proceedings, I=intevenor, Z=joined party. Domestic abuse waivers only apply for type 'A'",
                     deprecated: true,
                   },
                 },
@@ -1601,7 +1599,7 @@ class SwaggerDocs
                   },
                   client_involvement_type: {
                     type: :string,
-                    enum: CFEConstants::VALID_CLIENT_INVOLVEMENT_TYPES,
+                    enum: ProceedingType::VALID_CLIENT_INVOLVEMENT_TYPES,
                     example: "A",
                     description: "The client_involvement_type expected by CCMS",
                   },

--- a/app/lib/swagger_docs.rb
+++ b/app/lib/swagger_docs.rb
@@ -1580,7 +1580,6 @@ class SwaggerDocs
                     type: :string,
                     enum: ProceedingType::VALID_CLIENT_INVOLVEMENT_TYPES,
                     description: "CCMS Client Involvement type A=applicant/claimant/petitioner, D=Defendant, W=subject of proceedings, I=intevenor, Z=joined party. Domestic abuse waivers only apply for type 'A'",
-                    deprecated: true,
                   },
                 },
               },

--- a/app/models/proceeding_type.rb
+++ b/app/models/proceeding_type.rb
@@ -1,7 +1,16 @@
 class ProceedingType < ApplicationRecord
   belongs_to :assessment
 
-  validates :client_involvement_type, inclusion: { in: CFEConstants::VALID_CLIENT_INVOLVEMENT_TYPES,
+  # client_involvement_types
+  # Applicant/claimant/petitioner A
+  # Defendant/respondent D
+  # Subject of proceedings (child) W
+  # Intervenor I
+  # Joined party Z
+  # Domestic abuse waivers will only be applied for client_involvement_type == 'A'
+  VALID_CLIENT_INVOLVEMENT_TYPES = %w[A D W Z I].freeze
+
+  validates :client_involvement_type, inclusion: { in: VALID_CLIENT_INVOLVEMENT_TYPES,
                                                    message: "invalid client_involvement_type: %{value}",
                                                    allow_nil: true }
   validate :proceeding_type_code_validations

--- a/spec/cassettes/LegalFrameworkAPI_ThresholdWaivers/_call/successful_API_call/responds_to_calling_service_with_parsed_response.yml
+++ b/spec/cassettes/LegalFrameworkAPI_ThresholdWaivers/_call/successful_API_call/responds_to_calling_service_with_parsed_response.yml
@@ -5,7 +5,7 @@ http_interactions:
     uri: https://legal-framework-api-staging.cloud-platform.service.justice.gov.uk/threshold_waivers
     body:
       encoding: UTF-8
-      string: '{"request_id":"e76bd31f-dd62-444f-9d7d-a731b40b7eea","proceedings":[{"ccms_code":"DA001","client_involvement_type":"A"},{"ccms_code":"DA005","client_involvement_type":"Z"},{"ccms_code":"SE014","client_involvement_type":"A"}]}'
+      string: '{"request_id":"e76bd31f-dd62-444f-9d7d-a731b40b7eea","proceedings":[{"ccms_code":"DA001","client_involvement_type":"A"},{"ccms_code":"DA002","client_involvement_type":"D"},{"ccms_code":"DA003","client_involvement_type":"W"},{"ccms_code":"DA004","client_involvement_type":"I"},{"ccms_code":"DA005","client_involvement_type":"Z"},{"ccms_code":"SE014","client_involvement_type":"A"}]}'
     headers:
       User-Agent:
       - Faraday v1.10.3
@@ -21,42 +21,43 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 10 Mar 2023 15:37:38 GMT
+      - Wed, 15 Nov 2023 14:32:22 GMT
       Content-Type:
       - application/json; charset=utf-8
       Content-Length:
-      - '642'
+      - '1197'
       Connection:
       - keep-alive
       X-Frame-Options:
       - SAMEORIGIN
       X-Xss-Protection:
-      - 1; mode=block
+      - '0'
       X-Content-Type-Options:
       - nosniff
-      X-Download-Options:
-      - noopen
       X-Permitted-Cross-Domain-Policies:
       - none
       Referrer-Policy:
       - strict-origin-when-cross-origin
+      Vary:
+      - Accept, Origin
       Etag:
-      - W/"ea1a12281c2747e41a4d405b99ab05ca"
+      - W/"bac93e7297adcaeba0aefbcec39c267a"
       Cache-Control:
       - max-age=0, private, must-revalidate
       X-Request-Id:
-      - 51ff03c9861ef0fd294e8df3504cfe79
+      - ec2e8dd75c41e9b8eafc09b0fd332351
       X-Runtime:
-      - '0.048138'
-      Vary:
-      - Accept, Origin
+      - '0.038134'
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
     body:
       encoding: UTF-8
       string: '{"request_id":"e76bd31f-dd62-444f-9d7d-a731b40b7eea","success":true,"proceedings":[{"ccms_code":"DA001","full_s8_only":false,"matter_type":"Domestic
-        abuse","gross_income_upper":true,"disposable_income_upper":true,"capital_upper":true,"client_involvement_type":"A"},{"ccms_code":"DA005","full_s8_only":false,"matter_type":"Domestic
+        abuse","gross_income_upper":true,"disposable_income_upper":true,"capital_upper":true,"client_involvement_type":"A"},{"ccms_code":"DA002","full_s8_only":false,"matter_type":"Domestic
+        abuse","gross_income_upper":false,"disposable_income_upper":false,"capital_upper":false,"client_involvement_type":"D"},{"ccms_code":"DA003","full_s8_only":false,"matter_type":"Domestic
+        abuse","gross_income_upper":false,"disposable_income_upper":false,"capital_upper":false,"client_involvement_type":"W"},{"ccms_code":"DA004","full_s8_only":false,"matter_type":"Domestic
+        abuse","gross_income_upper":false,"disposable_income_upper":false,"capital_upper":false,"client_involvement_type":"I"},{"ccms_code":"DA005","full_s8_only":false,"matter_type":"Domestic
         abuse","gross_income_upper":false,"disposable_income_upper":false,"capital_upper":false,"client_involvement_type":"Z"},{"ccms_code":"SE014","full_s8_only":false,"matter_type":"Children
         - section 8","gross_income_upper":false,"disposable_income_upper":false,"capital_upper":false,"client_involvement_type":"A"}]}'
-  recorded_at: Fri, 10 Mar 2023 15:37:38 GMT
-recorded_with: VCR 6.1.0
+  recorded_at: Wed, 15 Nov 2023 14:32:22 GMT
+recorded_with: VCR 6.2.0

--- a/spec/factories/proceeding_type_factory.rb
+++ b/spec/factories/proceeding_type_factory.rb
@@ -3,7 +3,7 @@ FactoryBot.define do
     assessment
 
     sequence(:ccms_code) { |n| CFEConstants::VALID_PROCEEDING_TYPE_CCMS_CODES[n % CFEConstants::VALID_PROCEEDING_TYPE_CCMS_CODES.size] }
-    client_involvement_type { CFEConstants::VALID_CLIENT_INVOLVEMENT_TYPES.sample }
+    client_involvement_type { ProceedingType::VALID_CLIENT_INVOLVEMENT_TYPES.sample }
 
     trait :with_invalid_ccms_code do
       ccms_code { "XX1234" }

--- a/spec/models/proceeding_type_spec.rb
+++ b/spec/models/proceeding_type_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe ProceedingType do
     it "writes proceeding_type to the database" do
       expect {
         described_class.create(ccms_code: CFEConstants::VALID_PROCEEDING_TYPE_CCMS_CODES.sample,
-                               client_involvement_type: CFEConstants::VALID_CLIENT_INVOLVEMENT_TYPES.sample,
+                               client_involvement_type: ProceedingType::VALID_CLIENT_INVOLVEMENT_TYPES.sample,
                                assessment:)
       }.to change(described_class, :count).by(1)
     end

--- a/spec/services/legal_framework_api/threshold_waivers_spec.rb
+++ b/spec/services/legal_framework_api/threshold_waivers_spec.rb
@@ -6,12 +6,12 @@ RSpec.describe LegalFrameworkAPI::ThresholdWaivers do
   describe ".call" do
     let(:proceeding_type_data) do
       {
-        "DA001" => "A",
-        "DA002" => "D",
-        "DA003" => "W",
-        "DA004" => "I",
-        "DA005" => "Z",
-        "SE014" => "A",
+        DA001: "A",
+        DA002: "D",
+        DA003: "W",
+        DA004: "I",
+        DA005: "Z",
+        SE014: "A",
       }
     end
     let(:proceeding_type_details) { proceeding_type_data.map { |code, type| { ccms_code: code, client_involvement_type: type } } }
@@ -25,9 +25,9 @@ RSpec.describe LegalFrameworkAPI::ThresholdWaivers do
 
     # waivers are only set true for DA with client_involvement_type == 'A'
     let(:non_waived_types) do
-      %w[DA002 DA003 DA004 DA005].map do |code|
+      %i[DA002 DA003 DA004 DA005].map do |code|
         {
-          ccms_code: code,
+          ccms_code: code.to_s,
           full_s8_only: false,
           matter_type: "Domestic abuse",
           gross_income_upper: false,

--- a/spec/services/legal_framework_api/threshold_waivers_spec.rb
+++ b/spec/services/legal_framework_api/threshold_waivers_spec.rb
@@ -4,22 +4,17 @@ RSpec.describe LegalFrameworkAPI::ThresholdWaivers do
   before { allow(SecureRandom).to receive(:uuid).and_return(request_id) }
 
   describe ".call" do
-    let(:proceeding_type_details) do
-      [
-        {
-          ccms_code: "DA001",
-          client_involvement_type: "A",
-        },
-        {
-          ccms_code: "DA005",
-          client_involvement_type: "Z",
-        },
-        {
-          ccms_code: "SE014",
-          client_involvement_type: "A",
-        },
-      ]
+    let(:proceeding_type_data) do
+      {
+        "DA001" => "A",
+        "DA002" => "D",
+        "DA003" => "W",
+        "DA004" => "I",
+        "DA005" => "Z",
+        "SE014" => "A",
+      }
     end
+    let(:proceeding_type_details) { proceeding_type_data.map { |code, type| { ccms_code: code, client_involvement_type: type } } }
 
     let(:request_body) do
       {
@@ -28,6 +23,20 @@ RSpec.describe LegalFrameworkAPI::ThresholdWaivers do
       }.to_json
     end
 
+    # waivers are only set true for DA with client_involvement_type == 'A'
+    let(:non_waived_types) do
+      %w[DA002 DA003 DA004 DA005].map do |code|
+        {
+          ccms_code: code,
+          full_s8_only: false,
+          matter_type: "Domestic abuse",
+          gross_income_upper: false,
+          disposable_income_upper: false,
+          capital_upper: false,
+          client_involvement_type: proceeding_type_data.fetch(code),
+        }
+      end
+    end
     let(:expected_parsed_response) do
       {
         request_id: "e76bd31f-dd62-444f-9d7d-a731b40b7eea",
@@ -42,15 +51,7 @@ RSpec.describe LegalFrameworkAPI::ThresholdWaivers do
             capital_upper: true,
             client_involvement_type: "A",
           },
-          {
-            ccms_code: "DA005",
-            full_s8_only: false,
-            client_involvement_type: "Z",
-            gross_income_upper: false,
-            disposable_income_upper: false,
-            capital_upper: false,
-            matter_type: "Domestic abuse",
-          },
+        ] + non_waived_types + [
           {
             ccms_code: "SE014",
             full_s8_only: false,

--- a/swagger/v6/swagger.yaml
+++ b/swagger/v6/swagger.yaml
@@ -1631,7 +1631,6 @@ components:
               - SE099E
               - SE100E
               - SE101E
-              example: DA001
               description: A proxy for the type of law. Values beginning with DA are
                 considered domestic abuse cases. IM030 indicates an immigration case.
                 IA031 indicates an asylum case.
@@ -1643,9 +1642,9 @@ components:
               - W
               - Z
               - I
-              example: A
-              description: A CCMS client_involvement_type. This is not used in the
-                calculation, so can be set to any valid value.
+              description: CCMS Client Involvement type A=applicant/claimant/petitioner,
+                D=Defendant, W=subject of proceedings, I=intevenor, Z=joined party.
+                Domestic abuse waivers only apply for type 'A'
               deprecated: true
           additionalProperties: false
       ProceedingTypeResults:

--- a/swagger/v6/swagger.yaml
+++ b/swagger/v6/swagger.yaml
@@ -1645,7 +1645,6 @@ components:
               description: CCMS Client Involvement type A=applicant/claimant/petitioner,
                 D=Defendant, W=subject of proceedings, I=intevenor, Z=joined party.
                 Domestic abuse waivers only apply for type 'A'
-              deprecated: true
           additionalProperties: false
       ProceedingTypeResults:
         type: array

--- a/swagger/v7/swagger.yaml
+++ b/swagger/v7/swagger.yaml
@@ -1631,7 +1631,6 @@ components:
               - SE099E
               - SE100E
               - SE101E
-              example: DA001
               description: A proxy for the type of law. Values beginning with DA are
                 considered domestic abuse cases. IM030 indicates an immigration case.
                 IA031 indicates an asylum case.
@@ -1643,9 +1642,9 @@ components:
               - W
               - Z
               - I
-              example: A
-              description: A CCMS client_involvement_type. This is not used in the
-                calculation, so can be set to any valid value.
+              description: CCMS Client Involvement type A=applicant/claimant/petitioner,
+                D=Defendant, W=subject of proceedings, I=intevenor, Z=joined party.
+                Domestic abuse waivers only apply for type 'A'
               deprecated: true
           additionalProperties: false
       ProceedingTypeResults:

--- a/swagger/v7/swagger.yaml
+++ b/swagger/v7/swagger.yaml
@@ -1645,7 +1645,6 @@ components:
               description: CCMS Client Involvement type A=applicant/claimant/petitioner,
                 D=Defendant, W=subject of proceedings, I=intevenor, Z=joined party.
                 Domestic abuse waivers only apply for type 'A'
-              deprecated: true
           additionalProperties: false
       ProceedingTypeResults:
         type: array


### PR DESCRIPTION
https://dsdmoj.atlassian.net/browse/LEP-407

Document client_involvement_type both in the API and in the code where the valid types are listed.
Extended the LFA VCR test to cover all involvement types to back up hypothesis that waivers only apply when client_involvement_type === 'A' (applicant/claimant/petitioner)

---

## Checklists

Author: (before you ask people to review this PR)

- [x] Diff - review it, ensuring it contains only expected changes
- [x] Whitespace changes - avoid if possible, because they make diffs harder to read and conflicts more likely
- [ ] Changelog - add a line, if it meets the criteria
- [x] Secrets - no secrets should be added
- [x] Commit messages - say *why* the change was made
- [x] PR description - summarizes *what* changed and *why*, with a JIRA ticket ID
- [x] Tests pass - on CircleCI
- [x] Conflicts - resolve if Github reports them. e.g. with `git rebase main`

Reviewers remember:

- [ ] Jira ticket criteria are met
- [ ] Migrations - test migration and rollback: `rake db:migrate && rake db:rollback`
