### PR TITLE
Tidy request rerunner - use v6 API, and change readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -370,7 +370,7 @@ on a local machine
 
 3) RAILS_ENV=remote_database SECRET_KEY_BASE=anything rake rerun:requests
 
-This currently takes around 1 hour to run with 7300 requests from staging
+This currently takes around 5 minutes to run with 7500 requests from staging
 The output format of the diffs is 4 fields:
 
 a) +/-/~ addition, removal, change

--- a/app/services/request_rerunner.rb
+++ b/app/services/request_rerunner.rb
@@ -4,6 +4,7 @@ class RequestRerunner
     USER_AGENT = "REQUEST_RERUNNER".freeze
     HEADERS = { "CONTENT_TYPE" => "application/json", "Accept" => "application/json", 'USER-AGENT': USER_AGENT }.freeze
     BATCH_SIZE = 500
+    CFE_URL = "/v6/assessments".freeze
 
     def call
       faraday = Faraday.new(API_BASE_URL, headers: HEADERS) do |f|
@@ -26,7 +27,7 @@ class RequestRerunner
             original = standardize_response v6_request.response
             date = original.dig(:assessment, :submission_date)
 
-            faraday_response = faraday.post("/v7/assessments", v6_request.request)
+            faraday_response = faraday.post(CFE_URL, v6_request.request)
             if faraday_response.success?
               response = standardize_response(faraday_response.body)
               diffs = make_diffs original, response


### PR DESCRIPTION
No ticket

Use v6 CFE endpoint (v7 now incompatible with old requests) and change readme to reflect 5 minutes rather than 1 hour runtime

---

## Checklists

Author: (before you ask people to review this PR)

- [ ] Diff - review it, ensuring it contains only expected changes
- [ ] Whitespace changes - avoid if possible, because they make diffs harder to read and conflicts more likely
- [ ] Changelog - add a line, if it meets the criteria
- [ ] Secrets - no secrets should be added
- [ ] Commit messages - say *why* the change was made
- [ ] PR description - summarizes *what* changed and *why*, with a JIRA ticket ID
- [ ] Tests pass - on CircleCI
- [ ] Conflicts - resolve if Github reports them. e.g. with `git rebase main`

Reviewers remember:

- [ ] Jira ticket criteria are met
- [ ] Migrations - test migration and rollback: `rake db:migrate && rake db:rollback`
