### PR TITLE
LEP-410 Housing Benefit - more renames

### DIFF
--- a/app/services/calculators/housing_costs_calculator.rb
+++ b/app/services/calculators/housing_costs_calculator.rb
@@ -27,14 +27,13 @@ module Calculators
         housing_costs = housing_costs_bank + housing_costs_regular + housing_costs_cash
 
         # Housing benefit
-        housing_benefit_to_subtract = if StateBenefitsCalculator.housing_benefit_included_in_gross_income_and_allowed_housing_costs?(submission_date)
-                                        # Post-MTR: The part of the housing costs that are paid for by housing benefit is an allowable cost,
-                                        # i.e. nothing needs to be subtracted from housing costs when calculating allowed_housing_costs
-                                        0
-                                      else
-                                        # Pre-MTR: Housing cost allowed is NET of housing benefit
-                                        # i.e. subtract the housing benefit amount when calculating allowed_housing_costs
+        housing_benefit_to_subtract = if allowed_housing_costs_are_net_of_housing_benefit?(submission_date)
+                                        # Pre-MTR: Allowed housing costs are NET of housing benefit
+                                        # i.e. when calculating allowed_housing_costs we'll subtract the housing benefit amount
                                         monthly_housing_benefit
+                                      else
+                                        # Post-MTR: nothing needs to be subtracted from housing costs when calculating allowed_housing_costs
+                                        0
                                       end
 
         Result.new housing_costs:,
@@ -55,6 +54,13 @@ module Calculators
         else
           housing_costs - housing_benefit_to_subtract
         end
+      end
+
+      def allowed_housing_costs_are_net_of_housing_benefit?(submission_date)
+        # - True pre-MTR
+        # - False post-MTR
+        # i.e. the opposite of housing_benefit_included_in_gross_income
+        !StateBenefitsCalculator.housing_benefit_included_in_gross_income?(submission_date)
       end
 
       def housing_costs_cash(gross_income_summary)

--- a/app/services/calculators/state_benefits_calculator.rb
+++ b/app/services/calculators/state_benefits_calculator.rb
@@ -13,15 +13,15 @@ module Calculators
                      state_benefits_bank: state_benefits_bank(submission_date:, state_benefits:)
       end
 
-      # is housing benefit in income calculation (post MTR) or excluded from calculation (before)
-      def housing_benefit_in_standard_calculation?(submission_date)
+      # is housing benefit in income calculation (post MTR) or excluded (before)
+      def housing_benefit_included_in_gross_income_and_allowed_housing_costs?(submission_date)
         Threshold.value_for(:housing_benefit_in_gross_income, at: submission_date).present?
       end
 
     private
 
       def state_benefits_regular(regular_transactions, submission_date)
-        transactions = if housing_benefit_in_standard_calculation?(submission_date)
+        transactions = if housing_benefit_included_in_gross_income_and_allowed_housing_costs?(submission_date)
                          regular_transactions.with_operation_and_category(:credit, :benefits) +
                            regular_transactions.with_operation_and_category(:credit, :housing_benefit)
                        else
@@ -33,7 +33,7 @@ module Calculators
       def state_benefits_bank(submission_date:, state_benefits:)
         benefits = state_benefits.reject(&:exclude_from_gross_income)
         state_benefit_totals = benefits.sum { |sb| MonthlyEquivalentCalculator.call(collection: sb.state_benefit_payments) }
-        if housing_benefit_in_standard_calculation?(submission_date)
+        if housing_benefit_included_in_gross_income_and_allowed_housing_costs?(submission_date)
           state_benefit_totals + MonthlyEquivalentCalculator.call(collection: state_benefits.select(&:housing_benefit?).flat_map(&:state_benefit_payments))
         else
           state_benefit_totals


### PR DESCRIPTION
Following on from LEP-410, a few more adjustments to language to hopefully make this code clearer.

* `housing_benefit_in_standard_calculation` - "standard calculation" is a made-up term...sorry - let's use the specific terms "gross_income_and_allowed_housing_costs" 
* `housing_benefit` variable was not the amount that the person receives in housing benefit, in the case of post-MTR, so confusing. Renamed to `housing_benefit_to_subtract` to make it clear this figure was the amount of housing benefit that is subtracted from housing costs to get 'allowed housing costs'.
* Reworked the comments about board and lodging

https://dsdmoj.atlassian.net/browse/LEP-410

<!-- Describe *what* you did and *why* -->

---

## Checklists

Author: (before you ask people to review this PR)

- [ ] Diff - review it, ensuring it contains only expected changes
- [ ] Whitespace changes - avoid if possible, because they make diffs harder to read and conflicts more likely
- [ ] Changelog - add a line, if it meets the criteria
- [ ] Secrets - no secrets should be added
- [ ] Commit messages - say *why* the change was made
- [ ] PR description - summarizes *what* changed and *why*, with a JIRA ticket ID
- [ ] Tests pass - on CircleCI
- [ ] Conflicts - resolve if Github reports them. e.g. with `git rebase main`

Reviewers remember:

- [ ] Jira ticket criteria are met
- [ ] Migrations - test migration and rollback: `rake db:migrate && rake db:rollback`
