### PR TITLE
refactor non_means_tested? out of workflow

### DIFF
--- a/app/controllers/v6/assessments_controller.rb
+++ b/app/controllers/v6/assessments_controller.rb
@@ -23,17 +23,25 @@ module V6
                                 main_home_params: full_assessment_params.fetch(:properties, {})[:main_home],
                                 submission_date: create.assessment.submission_date) || return
 
-        partner_params = full_assessment_params[:partner]
-        full = if partner_params.present?
-                 partner = person_data(input_params: partner_params,
-                                       model_params: partner_params.fetch(:partner, {}),
-                                       irregular_income_params: { payments: partner_params.fetch(:irregular_incomes, []) },
-                                       submission_date: create.assessment.submission_date,
-                                       main_home_params: nil,
-                                       additional_properties_params: partner_params) || return
-                 Workflows::PersonWorkflow.with_partner(assessment: create.assessment, applicant:, partner:)
+        full = if Workflows::MainWorkflow.non_means_tested?(proceeding_type_codes: create.assessment.proceeding_types.pluck(:ccms_code),
+                                                            receives_asylum_support: applicant.details.receives_asylum_support,
+                                                            submission_date: create.assessment.submission_date)
+                 Workflows::PersonWorkflow.blank_calculation_result(submission_date: create.assessment.submission_date,
+                                                                    level_of_help: create.assessment.level_of_help,
+                                                                    proceeding_types: create.assessment.proceeding_types)
                else
-                 Workflows::PersonWorkflow.without_partner(assessment: create.assessment, applicant:)
+                 partner_params = full_assessment_params[:partner]
+                 if partner_params.present?
+                   partner = person_data(input_params: partner_params,
+                                         model_params: partner_params.fetch(:partner, {}),
+                                         irregular_income_params: { payments: partner_params.fetch(:irregular_incomes, []) },
+                                         submission_date: create.assessment.submission_date,
+                                         main_home_params: nil,
+                                         additional_properties_params: partner_params) || return
+                   Workflows::PersonWorkflow.with_partner(assessment: create.assessment, applicant:, partner:)
+                 else
+                   Workflows::PersonWorkflow.without_partner(assessment: create.assessment, applicant:)
+                 end
                end
         assessment_params = full_assessment_params.fetch(:assessment)
         eligibility_result = ResultWrapper.new(result: full.eligibility_result,

--- a/app/lib/eligibility_results.rb
+++ b/app/lib/eligibility_results.rb
@@ -1,4 +1,18 @@
 class EligibilityResults
+  class BlankEligibilityResult
+    def initialize(proceeding_types)
+      @proceeding_types = proceeding_types
+    end
+
+    def assessment_results
+      @proceeding_types.index_with { :eligible }
+    end
+
+    def summarized_assessment_result
+      :eligible
+    end
+  end
+
   class << self
     def without_partner(proceeding_types:, submission_date:,
                         applicant:, level_of_help:)

--- a/app/lib/eligibility_results.rb
+++ b/app/lib/eligibility_results.rb
@@ -11,6 +11,20 @@ class EligibilityResults
     def summarized_assessment_result
       :eligible
     end
+
+    # This is used when the assessment is non means tested so there are no thresholds
+    # worth reporting anything about
+    def gross_eligibilities
+      []
+    end
+
+    def disposable_eligibilities
+      []
+    end
+
+    def capital_eligibilities
+      []
+    end
   end
 
   class << self

--- a/app/services/workflows/main_workflow.rb
+++ b/app/services/workflows/main_workflow.rb
@@ -11,14 +11,19 @@ module Workflows
         call(applicant:, partner: nil, proceeding_types:, level_of_help:, submission_date:)
       end
 
+      def non_means_tested?(proceeding_type_codes:, receives_asylum_support:, submission_date:)
+        # skip proceeding types check if applicant receives asylum support after MTR go-live date
+        if asylum_support_is_non_means_tested_for_all_matter_types?(submission_date)
+          receives_asylum_support
+        else
+          proceeding_type_codes.map(&:to_sym).all? { _1.in?(CFEConstants::IMMIGRATION_AND_ASYLUM_PROCEEDING_TYPE_CCMS_CODES) } && receives_asylum_support
+        end
+      end
+
     private
 
       def call(applicant:, partner:, proceeding_types:, level_of_help:, submission_date:)
-        if non_means_tested?(proceeding_type_codes: proceeding_types.pluck(:ccms_code),
-                             receives_asylum_support: applicant.details.receives_asylum_support, submission_date:)
-          blank_calculation_result(submission_date:,
-                                   level_of_help:)
-        elsif applicant.details.receives_qualifying_benefit?
+        if applicant.details.receives_qualifying_benefit?
           calculation_output = if partner.present?
                                  PassportedWorkflow.with_partner(capitals_data: applicant.capitals_data,
                                                                  partner_capitals_data: partner.capitals_data,
@@ -40,25 +45,8 @@ module Workflows
         end
       end
 
-      def non_means_tested?(proceeding_type_codes:, receives_asylum_support:, submission_date:)
-        # skip proceeding types check if applicant receives asylum support after MTR go-live date
-        if asylum_support_is_non_means_tested_for_all_matter_types?(submission_date)
-          receives_asylum_support
-        else
-          proceeding_type_codes.map(&:to_sym).all? { _1.in?(CFEConstants::IMMIGRATION_AND_ASYLUM_PROCEEDING_TYPE_CCMS_CODES) } && receives_asylum_support
-        end
-      end
-
       def asylum_support_is_non_means_tested_for_all_matter_types?(submission_date)
         !!Threshold.value_for(:asylum_support_is_non_means_tested_for_all_matter_types, at: submission_date)
-      end
-
-      def blank_calculation_result(level_of_help:, submission_date:)
-        calculation_output = CalculationOutput.new(level_of_help:, submission_date:,
-                                                   gross_income_subtotals: GrossIncome::Unassessed.new(level_of_help:, submission_date:),
-                                                   disposable_income_subtotals: DisposableIncome::Unassessed.new(level_of_help:, submission_date:),
-                                                   capital_subtotals: Capital::Unassessed.new(submission_date:, level_of_help:))
-        Result.new calculation_output:, remarks: [], assessment_result: :eligible
       end
     end
   end

--- a/app/services/workflows/person_workflow.rb
+++ b/app/services/workflows/person_workflow.rb
@@ -3,9 +3,10 @@ module Workflows
     class << self
       def blank_calculation_result(proceeding_types:, level_of_help:, submission_date:)
         calculation_output = CalculationOutput.new(
+          level_of_help:, submission_date:,
           gross_income_subtotals: GrossIncome::Unassessed.new(level_of_help:, submission_date:),
           disposable_income_subtotals: DisposableIncome::Unassessed.new(level_of_help:, submission_date:),
-          capital_subtotals: Capital::Unassessed.new(submission_date:, level_of_help:),
+          capital_subtotals: Capital::Unassessed.new(submission_date:, level_of_help:)
         )
         workflow = Workflows::MainWorkflow::Result.new calculation_output:, remarks: [], assessment_result: :eligible
 

--- a/app/services/workflows/person_workflow.rb
+++ b/app/services/workflows/person_workflow.rb
@@ -1,6 +1,18 @@
 module Workflows
   class PersonWorkflow
     class << self
+      def blank_calculation_result(proceeding_types:, level_of_help:, submission_date:)
+        calculation_output = CalculationOutput.new(
+          gross_income_subtotals: GrossIncome::Unassessed.new(level_of_help:, submission_date:),
+          disposable_income_subtotals: DisposableIncome::Unassessed.new(level_of_help:, submission_date:),
+          capital_subtotals: Capital::Unassessed.new(submission_date:, level_of_help:),
+        )
+        workflow = Workflows::MainWorkflow::Result.new calculation_output:, remarks: [], assessment_result: :eligible
+
+        er = EligibilityResults::BlankEligibilityResult.new(proceeding_types)
+        ResultAndEligibility.new workflow_result: workflow, eligibility_result: er
+      end
+
       def without_partner(assessment:, applicant:)
         result = Workflows::MainWorkflow.without_partner(submission_date: assessment.submission_date, level_of_help: assessment.level_of_help,
                                                          proceeding_types: assessment.proceeding_types,

--- a/spec/services/workflows/main_workflow_spec.rb
+++ b/spec/services/workflows/main_workflow_spec.rb
@@ -35,18 +35,14 @@ module Workflows
                                         applicant: build(:person_data, details: applicant))
       end
 
-      context "for immigration/asylum proceeding types" do
+      describe "#non_means_tested?" do
         context "before MTR changes, require proceeding type check" do
           let(:proceedings_hash) { [%w[IM030 A]] }
 
-          it "does not call a workflow" do
-            expect(PassportedWorkflow).not_to receive(:without_partner)
-            expect(NonPassportedWorkflow).not_to receive(:with_partner)
-            expect(NonPassportedWorkflow).not_to receive(:without_partner)
-            described_class.without_partner(submission_date: assessment.submission_date, level_of_help: assessment.level_of_help,
-                                            proceeding_types: assessment.proceeding_types,
-                                            applicant: build(:person_data,
-                                                             details: applicant))
+          it "is not means tested" do
+            expect(described_class.non_means_tested?(submission_date: assessment.submission_date,
+                                                     receives_asylum_support: applicant.receives_asylum_support,
+                                                     proceeding_type_codes: assessment.proceeding_types.map(&:ccms_code))).to eq(true)
           end
         end
 
@@ -57,12 +53,10 @@ module Workflows
             travel_back
           end
 
-          it "does not call a workflow" do
-            expect(PassportedWorkflow).not_to receive(:without_partner)
-            expect(NonPassportedWorkflow).not_to receive(:without_partner)
-            described_class.without_partner(proceeding_types: assessment.proceeding_types, level_of_help: assessment.level_of_help,
-                                            submission_date: assessment.submission_date,
-                                            applicant: build(:person_data, details: applicant))
+          it "is not means tested" do
+            expect(described_class.non_means_tested?(submission_date: assessment.submission_date,
+                                                     receives_asylum_support: applicant.receives_asylum_support,
+                                                     proceeding_type_codes: assessment.proceeding_types.map(&:ccms_code))).to eq(true)
           end
         end
       end


### PR DESCRIPTION
https://dsdmoj.atlassian.net/browse/LEP-420

Move non_means_tested? method higher up the call chain

---

## Checklists

Author: (before you ask people to review this PR)

- [x] Diff - review it, ensuring it contains only expected changes
- [x] Whitespace changes - avoid if possible, because they make diffs harder to read and conflicts more likely
- [x] Changelog - add a line, if it meets the criteria
- [x] Secrets - no secrets should be added
- [x] Commit messages - say *why* the change was made
- [x] PR description - summarizes *what* changed and *why*, with a JIRA ticket ID
- [x] Tests pass - on CircleCI
- [x] Conflicts - resolve if Github reports them. e.g. with `git rebase main`

Reviewers remember:

- [ ] Jira ticket criteria are met
- [ ] Migrations - test migration and rollback: `rake db:migrate && rake db:rollback`
