### PR TITLE
Fix asylum support issue - iterate through proceeding types if supplied

### DIFF
--- a/app/lib/eligibility_results.rb
+++ b/app/lib/eligibility_results.rb
@@ -1,7 +1,9 @@
 class EligibilityResults
   class BlankEligibilityResult
-    def initialize(proceeding_types)
+    def initialize(proceeding_types:, submission_date:, level_of_help:)
       @proceeding_types = proceeding_types
+      @submission_date = submission_date
+      @level_of_help = level_of_help
     end
 
     def assessment_results
@@ -9,15 +11,25 @@ class EligibilityResults
     end
 
     def gross_eligibilities
-      []
+      Creators::GrossIncomeEligibilityCreator.unassessed(
+        proceeding_types: @proceeding_types,
+        submission_date: @submission_date,
+        level_of_help: @level_of_help,
+      )
     end
 
     def disposable_eligibilities
-      []
+      Creators::DisposableIncomeEligibilityCreator.unassessed(
+        proceeding_types: @proceeding_types,
+        submission_date: @submission_date,
+        level_of_help: @level_of_help,
+      )
     end
 
     def capital_eligibilities
-      []
+      Creators::CapitalEligibilityCreator.unassessed proceeding_types: @proceeding_types,
+                                                     submission_date: @submission_date,
+                                                     level_of_help: @level_of_help
     end
   end
 

--- a/app/services/creators/capital_eligibility_creator.rb
+++ b/app/services/creators/capital_eligibility_creator.rb
@@ -14,6 +14,19 @@ module Creators
         end
       end
 
+      def unassessed(proceeding_types:, level_of_help:, submission_date:)
+        proceeding_types.map do |proceeding_type|
+          threshold = thresholds_for(proceeding_type:, submission_date:, level_of_help:)
+
+          Eligibility::Capital.new(
+            proceeding_type:,
+            upper_threshold: threshold.upper_threshold,
+            lower_threshold: threshold.lower_threshold,
+            assessment_result: "not_calculated",
+          )
+        end
+      end
+
       def assessment_results(proceeding_types:, level_of_help:, submission_date:, assessed_capital:)
         proceeding_types.index_with do |proceeding_type|
           assessed_result(assessed_capital:, threshold: thresholds_for(proceeding_type:, submission_date:, level_of_help:))

--- a/app/services/workflows/non_means_tested_workflow.rb
+++ b/app/services/workflows/non_means_tested_workflow.rb
@@ -21,7 +21,7 @@ module Workflows
         )
         workflow = Workflows::MainWorkflow::Result.new calculation_output:, remarks: [], assessment_result: :eligible
 
-        er = EligibilityResults::BlankEligibilityResult.new(proceeding_types)
+        er = EligibilityResults::BlankEligibilityResult.new(proceeding_types:, level_of_help:, submission_date:)
         ResultAndEligibility.new workflow_result: workflow, eligibility_result: er
       end
 


### PR DESCRIPTION
https://dsdmoj.atlassian.net/browse/LEP-XXX

When calculation in non means tested, still iterate through proceeding types if supplied and say 'not_calculated'

---

## Checklists

Author: (before you ask people to review this PR)

- [ ] Diff - review it, ensuring it contains only expected changes
- [ ] Whitespace changes - avoid if possible, because they make diffs harder to read and conflicts more likely
- [ ] Changelog - add a line, if it meets the criteria
- [ ] Secrets - no secrets should be added
- [ ] Commit messages - say *why* the change was made
- [ ] PR description - summarizes *what* changed and *why*, with a JIRA ticket ID
- [ ] Tests pass - on CircleCI
- [ ] Conflicts - resolve if Github reports them. e.g. with `git rebase main`

Reviewers remember:

- [ ] Jira ticket criteria are met
- [ ] Migrations - test migration and rollback: `rake db:migrate && rake db:rollback`
