### PR TITLE
Lep 464 fix bank holiday caching

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -21,7 +21,6 @@ gem "puma", "~> 6.4"
 # gem 'mini_magick', '~> 4.8'
 
 gem "faraday", "~> 1.10"
-gem "faraday-http-cache"
 
 gem "sentry-rails", ">= 5.8.0"
 gem "sentry-ruby"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -187,8 +187,6 @@ GEM
     faraday-em_http (1.0.0)
     faraday-em_synchrony (1.0.0)
     faraday-excon (1.1.0)
-    faraday-http-cache (2.5.0)
-      faraday (>= 0.8)
     faraday-httpclient (1.0.1)
     faraday-multipart (1.0.4)
       multipart-post (~> 2)
@@ -558,7 +556,6 @@ DEPENDENCIES
   factory_bot_rails (>= 6.2.0)
   faker
   faraday (~> 1.10)
-  faraday-http-cache
   google_drive (>= 3.0.7)
   govuk_notify_rails (~> 2.2.0)
   guard

--- a/app/constants/cfe_constants.rb
+++ b/app/constants/cfe_constants.rb
@@ -56,11 +56,6 @@ module CFEConstants
   VALID_IRREGULAR_INCOME_FREQUENCIES = [MONTHLY_FREQUENCY, ANNUAL_FREQUENCY, QUARTERLY_FREQUENCY].freeze
   VALID_IRREGULAR_INCOME_TYPES = [STUDENT_LOAN, UNSPECIFIED_SOURCE].freeze
 
-  # Date and bank holidays
-  #
-  GOVUK_BANK_HOLIDAY_API_URL = "https://www.gov.uk/bank-holidays.json".freeze
-  GOVUK_BANK_HOLIDAY_DEFAULT_GROUP = "england-and-wales".freeze
-
   # Frequencies
   #
   VALID_REGULAR_TRANSACTION_FREQUENCIES = %i[three_monthly monthly four_weekly two_weekly weekly unknown].freeze

--- a/app/services/govuk_bank_holiday_retriever.rb
+++ b/app/services/govuk_bank_holiday_retriever.rb
@@ -1,30 +1,29 @@
 class GovukBankHolidayRetriever
-  def self.dates
-    new.dates(CFEConstants::GOVUK_BANK_HOLIDAY_DEFAULT_GROUP)
-  end
+  # Date and bank holidays
+  #
+  GOVUK_BANK_HOLIDAY_API_URL = "https://www.gov.uk/bank-holidays.json".freeze
+  GOVUK_BANK_HOLIDAY_DEFAULT_GROUP = "england-and-wales".freeze
 
-  def dates(group)
-    JSON.parse(response.body).dig(group, "events")&.pluck("date")
-  end
-
-private
-
-  def response
-    # The Faraday::HttpCache middleware is slightly 'broken' as it doesn't respect the TTL of the
-    # response, and relies on the expiry time set on the 'store' object passed to
-    # it. k8s pods get recycled regularly anyway, so the expiry time is unlikely
-    # to be exceeded
-    store = ActiveSupport::Cache.lookup_store(:file_store, "tmp/cache", expires_in: 10.days)
-    client = Faraday.new do |builder|
-      builder.use Faraday::HttpCache, store:, strategy: Faraday::HttpCache::Strategies::ByUrl, logger: Rails.logger
-      builder.adapter Faraday.default_adapter
-      builder.response :raise_error
+  class << self
+    def dates
+      JSON.parse(response_body).dig(GOVUK_BANK_HOLIDAY_DEFAULT_GROUP, "events").pluck("date")
     end
 
-    @response ||= client.get(uri)
-  end
+  private
 
-  def uri
-    URI.parse(CFEConstants::GOVUK_BANK_HOLIDAY_API_URL)
+    def response_body
+      client = Faraday.new do |builder|
+        builder.adapter Faraday.default_adapter
+        builder.response :raise_error
+      end
+
+      Rails.cache.fetch(uri, expires_in: 10.days) do
+        client.get(uri).body
+      end
+    end
+
+    def uri
+      URI.parse(GOVUK_BANK_HOLIDAY_API_URL)
+    end
   end
 end

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -38,7 +38,7 @@ Rails.application.configure do
   # Show full error reports and disable caching.
   config.consider_all_requests_local = true
   config.action_controller.perform_caching = false
-  config.cache_store = :null_store
+  config.cache_store = :memory_store
 
   # Render exception templates for rescuable exceptions and raise for other exceptions.
   config.action_dispatch.show_exceptions = :rescuable

--- a/spec/services/govuk_bank_holiday_retriever_spec.rb
+++ b/spec/services/govuk_bank_holiday_retriever_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe GovukBankHolidayRetriever do
 
     before do
       bank_holiday_stub
-      FileUtils.rm_rf("/tmp/cache")
+      Rails.cache.clear
     end
 
     context "data returned from API" do


### PR DESCRIPTION
https://dsdmoj.atlassian.net/browse/LEP-464

Remove Faraday caching middleware as bank holidays are no longer marked cachable

---

## Checklists

Author: (before you ask people to review this PR)

- [x] Diff - review it, ensuring it contains only expected changes
- [x] Whitespace changes - avoid if possible, because they make diffs harder to read and conflicts more likely
- [x] Changelog - add a line, if it meets the criteria
- [x] Secrets - no secrets should be added
- [x] Commit messages - say *why* the change was made
- [x] PR description - summarizes *what* changed and *why*, with a JIRA ticket ID
- [x] Tests pass - on CircleCI
- [x] Conflicts - resolve if Github reports them. e.g. with `git rebase main`

Reviewers remember:

- [ ] Jira ticket criteria are met
- [ ] Migrations - test migration and rollback: `rake db:migrate && rake db:rollback`
