### PR TITLE
LEP-415 enable YJIT

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,6 +36,7 @@ executors:
           - PGHOST=localhost
           - PGUSER=user
           - TZ: "Europe/London"
+          - RUBY_YJIT_ENABLE: "1"
       - image: cimg/postgres:14.8
         environment:
           - POSTGRES_USER=user

--- a/deploy/helm/templates/_envs.tpl
+++ b/deploy/helm/templates/_envs.tpl
@@ -47,6 +47,8 @@ env:
         key: sentry-dsn
   - name: RAILS_ENV
     value: production
+  - name: RUBY_YJIT_ENABLE
+    value: '1'
   - name: RAILS_LOG_TO_STDOUT
     value: 'true'
   - name: USE_TEST_THRESHOLD_DATA


### PR DESCRIPTION
https://dsdmoj.atlassian.net/browse/LEP-415

Enable YJIT, as it will be enabled by default on ruby 3.3 

Performance was measured using the request_rerunner, but showed no noticeable improvements. It seems likely that performance is still dominated by i/o (database access)

---

## Checklists

Author: (before you ask people to review this PR)

- [x] Diff - review it, ensuring it contains only expected changes
- [x] Whitespace changes - avoid if possible, because they make diffs harder to read and conflicts more likely
- [x] Changelog - add a line, if it meets the criteria
- [x] Secrets - no secrets should be added
- [x] Commit messages - say *why* the change was made
- [x] PR description - summarizes *what* changed and *why*, with a JIRA ticket ID
- [x] Tests pass - on CircleCI
- [x] Conflicts - resolve if Github reports them. e.g. with `git rebase main`

Reviewers remember:

- [ ] Jira ticket criteria are met
- [ ] Migrations - test migration and rollback: `rake db:migrate && rake db:rollback`
