### PR TITLE
Remove spreadsheet parser from production

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -46,11 +46,6 @@ gem "dibber"
 # Adds Statistical methods to objects such as arrays
 gem "descriptive_statistics", require: "descriptive_statistics/safe"
 
-gem "google_drive", ">= 3.0.7"
-
-# parse spreadsheets
-gem "roo", "~> 2.10.1"
-
 # Required following upgrade to ruby 3.1.0
 gem "net-imap"
 gem "net-pop"
@@ -82,6 +77,11 @@ group :development, :test do
   gem "rswag-specs"
   gem "rubocop-govuk", require: false
   gem "rubocop-performance"
+
+  # download spreadsheets
+  gem "google_drive", ">= 3.0.7"
+  # parse spreadsheets
+  gem "roo", "~> 2.10.0"
 
   # This is needed to allow IntelliJ to run cucumber scenarios individually without producing
   # strange errors and not running the feature.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -580,7 +580,7 @@ DEPENDENCIES
   puma (~> 6.4)
   rack-mini-profiler
   rails (> 7.1, < 7.2)
-  roo (~> 2.10.1)
+  roo (~> 2.10.0)
   rspec-rails (~> 6.1)
   rspec_junit_formatter
   rswag-api


### PR DESCRIPTION
No ticket

Google drive and the roo spreadsheet parser are not needed in production builds, so remove them

---

## Checklists

Author: (before you ask people to review this PR)

- [x] Diff - review it, ensuring it contains only expected changes
- [x] Whitespace changes - avoid if possible, because they make diffs harder to read and conflicts more likely
- [x] Changelog - add a line, if it meets the criteria
- [x] Secrets - no secrets should be added
- [x] Commit messages - say *why* the change was made
- [x] PR description - summarizes *what* changed and *why*, with a JIRA ticket ID
- [x] Tests pass - on CircleCI
- [x] Conflicts - resolve if Github reports them. e.g. with `git rebase main`

Reviewers remember:

- [ ] Jira ticket criteria are met
- [ ] Migrations - test migration and rollback: `rake db:migrate && rake db:rollback`
