### PR TITLE
LEP-495 add a flag to enable a future threshold file to be in scope

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,14 +245,15 @@ Obtain the `.env` file from 1Password - look in the folder `LAA-Eligibility-Plat
 
 Environment variables:
 
-| Name | Value examples & commentary |
-| ---- | --------------------------- |
-| GOOGLE_SHEETS_PRIVATE_KEY_ID | (secret) |
-| GOOGLE_SHEETS_PRIVATE_KEY | (secret) |
-| GOOGLE_SHEETS_CLIENT_EMAIL | (secret) |
-| GOOGLE_SHEETS_CLIENT_ID | (secret) |
-| RUNNING_AS_GITHUB_WORKFLOW | `TRUE` / `FALSE` |
-| LEGAL_FRAMEWORK_API_HOST | `https://legal-framework-api-staging.apps.live-1.cloud-platform.service.justice.gov.uk` |
+| Name                         | Value examples & commentary                                                             |
+|------------------------------|-----------------------------------------------------------------------------------------|
+| GOOGLE_SHEETS_PRIVATE_KEY_ID | (secret)                                                                                |
+| GOOGLE_SHEETS_PRIVATE_KEY    | (secret)                                                                                |
+| GOOGLE_SHEETS_CLIENT_EMAIL   | (secret)                                                                                |
+| GOOGLE_SHEETS_CLIENT_ID      | (secret)                                                                                |
+| RUNNING_AS_GITHUB_WORKFLOW   | `TRUE` / `FALSE`                                                                        |
+| LEGAL_FRAMEWORK_API_HOST     | `https://legal-framework-api-staging.apps.live-1.cloud-platform.service.justice.gov.uk` |
+| FUTURE_THRESHOLD_FILE        | 'mtr-2026.yml' - allows (e.g. MTR) a future dated file to be activated (for testing)    |
 
 #### Running RSpec tests
 

--- a/app/models/threshold.rb
+++ b/app/models/threshold.rb
@@ -1,38 +1,46 @@
 class Threshold
-  class << self
-    def data
-      @data ||= load_data
-    end
+  def initialize(data_folder_path = "config/thresholds")
+    @threshold_data = load_data data_folder_path
+  end
 
-    def load_data
-      data = {}
-      index = YAML.safe_load_file(Rails.root.join(data_folder_path, "values.yml"), permitted_classes: [Date])
-      index.each do |date, filename|
-        hash = YAML.safe_load_file(Rails.root.join(filename), permitted_classes: [Date]).deep_symbolize_keys
-        data[date.beginning_of_day] = hash if threshold_loadable?(hash)
+  def value_for(item, at:)
+    key = threshold_data.keys.select { |time| time <= at }.max || threshold_data.keys.min
+    threshold = threshold_data[key]
+    threshold[item.to_sym]
+  end
+
+private
+
+  attr_reader :threshold_data
+
+  def load_data(data_folder_path)
+    index = YAML.safe_load_file(Rails.root.join(data_folder_path, "values.yml"), permitted_classes: [Date])
+    data = index.map do |date, filename|
+      hash = YAML.safe_load_file(Rails.root.join(filename), permitted_classes: [Date]).deep_symbolize_keys
+      if Rails.configuration.x.future_test_data_file == filename.split("/").last
+        [Time.zone.today, hash]
+      else
+        [date.beginning_of_day, hash]
       end
-      data
     end
+    data.select { |_date, hash| threshold_loadable?(hash) }.to_h
+  end
 
+  def threshold_loadable?(hash)
+    return true unless hash.key?(:test_only)
+
+    Rails.configuration.x.use_test_threshold_data == "true"
+  end
+
+  class << self
     def value_for(item, at:)
-      key = data.keys.select { |time| time <= at }.max || data.keys.min
-      threshold = data[key]
-      threshold[item.to_sym]
+      threshold.value_for(item, at:)
     end
 
-    def data_folder_path=(new_path)
-      @data_folder_path = new_path
-      @data = nil
-    end
+  private
 
-    def data_folder_path
-      @data_folder_path ||= Rails.root.join("config/thresholds")
-    end
-
-    def threshold_loadable?(hash)
-      return true unless hash.key?(:test_only)
-
-      Rails.configuration.x.use_test_threshold_data == "true"
+    def threshold
+      @threshold ||= Threshold.new
     end
   end
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -48,6 +48,8 @@ module CfeCivil
     config.x.use_test_threshold_data = ENV["USE_TEST_THRESHOLD_DATA"]
 
     config.x.legal_framework_api_host = ENV["LEGAL_FRAMEWORK_API_HOST"]
+
+    config.x.future_test_data_file = ENV["FUTURE_THRESHOLD_FILE"]
   end
 end
 

--- a/spec/models/threshold_spec.rb
+++ b/spec/models/threshold_spec.rb
@@ -121,13 +121,25 @@ RSpec.describe Threshold do
   end
 
   context "MTR" do
-    context "when future test file active" do
-      before { allow(Rails.configuration.x).to receive(:future_test_data_file).and_return("mtr-2026.yml") }
+    context "when setting future test file" do
+      before { allow(Rails.configuration.x).to receive(:future_test_data_file).and_return(override_filename) }
 
       let(:submission_date) { Time.zone.today }
 
-      it "invokes the MTR config early regardless of submission date" do
-        expect(described_class.new.value_for(:fixed_employment_allowance, at: submission_date)).to eq 66.0
+      context "when future test file active" do
+        let(:override_filename) { "mtr-2026.yml" }
+
+        it "invokes the MTR config early regardless of submission date" do
+          expect(described_class.new.value_for(:fixed_employment_allowance, at: submission_date)).to eq 66.0
+        end
+      end
+
+      context "when future test file inactive" do
+        let(:override_filename) { "" }
+
+        it "doesnt invoke MTR threshold" do
+          expect(described_class.new.value_for(:fixed_employment_allowance, at: submission_date)).to eq 45.0
+        end
       end
     end
 

--- a/spec/models/threshold_spec.rb
+++ b/spec/models/threshold_spec.rb
@@ -2,21 +2,16 @@ require "rails_helper"
 
 RSpec.describe Threshold do
   context "using test data files" do
-    let(:threshold_test_data_folder) { Rails.root.join("spec/data/thresholds") }
+    let(:threshold_test_data_folder) { "spec/data/thresholds" }
+    let(:thresholds) { described_class.new(threshold_test_data_folder) }
 
     describe ".value_for" do
-      around do |example|
-        described_class.data_folder_path = threshold_test_data_folder
-        example.run
-        described_class.data_folder_path = nil
-      end
-
       let(:time) { Time.zone.parse("9-June-2019 12:35") }
       let(:test_data_file) { "#{threshold_test_data_folder}/2019-04-08.yml" }
       let(:data) { YAML.load_file(test_data_file).deep_symbolize_keys }
 
       it "returns the expected value" do
-        expect(described_class.value_for(:capital_lower_certificated, at: time)).to eq(data[:capital_lower_certificated])
+        expect(thresholds.value_for(:capital_lower_certificated, at: time)).to eq(data[:capital_lower_certificated])
       end
 
       context "for dates before oldest" do
@@ -25,7 +20,7 @@ RSpec.describe Threshold do
         let(:data) { YAML.load_file("#{threshold_test_data_folder}/2018-04-08.yml").deep_symbolize_keys }
 
         it "returns the value from oldest file" do
-          expect(described_class.value_for(:capital_lower_certificated, at: time)).to eq(data[:capital_lower_certificated])
+          expect(thresholds.value_for(:capital_lower_certificated, at: time)).to eq(data[:capital_lower_certificated])
         end
       end
 
@@ -37,7 +32,7 @@ RSpec.describe Threshold do
             let(:time) { Time.zone.parse("1-Dec-2020 12:33") }
 
             it "returns value from the April 2020 file" do
-              expect(described_class.value_for(:property_maximum_mortgage_allowance, at: time)).to eq 666_666_666_666
+              expect(thresholds.value_for(:property_maximum_mortgage_allowance, at: time)).to eq 666_666_666_666
             end
           end
 
@@ -45,7 +40,7 @@ RSpec.describe Threshold do
             let(:time) { Time.zone.parse("15-Dec-2020 11:48") }
 
             it "returns mortgage allowance Test file" do
-              expect(described_class.value_for(:property_maximum_mortgage_allowance, at: time)).to eq 888_888_888_888
+              expect(thresholds.value_for(:property_maximum_mortgage_allowance, at: time)).to eq 888_888_888_888
             end
           end
 
@@ -53,7 +48,7 @@ RSpec.describe Threshold do
             let(:time) { Time.zone.parse("1-Jan-2030 12:33") }
 
             it "returns value from the Jan 2021 file" do
-              expect(described_class.value_for(:property_maximum_mortgage_allowance, at: time)).to eq 999_999_999_999
+              expect(thresholds.value_for(:property_maximum_mortgage_allowance, at: time)).to eq 999_999_999_999
             end
           end
         end
@@ -65,7 +60,7 @@ RSpec.describe Threshold do
             let(:time) { Time.zone.parse("1-Dec-2020 12:33") }
 
             it "returns value from the April 2020 file" do
-              expect(described_class.value_for(:property_maximum_mortgage_allowance, at: time)).to eq 666_666_666_666
+              expect(thresholds.value_for(:property_maximum_mortgage_allowance, at: time)).to eq 666_666_666_666
             end
           end
 
@@ -73,7 +68,7 @@ RSpec.describe Threshold do
             let(:time) { Time.zone.parse("15-Dec-2020 11:48") }
 
             it "returns value from the April 2020 file" do
-              expect(described_class.value_for(:property_maximum_mortgage_allowance, at: time)).to eq 666_666_666_666
+              expect(thresholds.value_for(:property_maximum_mortgage_allowance, at: time)).to eq 666_666_666_666
             end
           end
 
@@ -126,6 +121,16 @@ RSpec.describe Threshold do
   end
 
   context "MTR" do
+    context "when future test file active" do
+      before { allow(Rails.configuration.x).to receive(:future_test_data_file).and_return("mtr-2026.yml") }
+
+      let(:submission_date) { Time.zone.today }
+
+      it "invokes the MTR config early regardless of submission date" do
+        expect(described_class.new.value_for(:fixed_employment_allowance, at: submission_date)).to eq 66.0
+      end
+    end
+
     context "with MTR" do
       let(:submission_date) { Date.new(2525, 4, 20) }
 


### PR DESCRIPTION
https://dsdmoj.atlassian.net/browse/LEP-495

Add a config variable which allows 'promotion' of a future config file into todays date. Will be used to create an MTR test environment where the variable is set to mtr-2026.yml 

The existing code had to be re-worked to make it testable - it used a class-scope lazy loaded 'instance' variable which could never be re-loaded

---

## Checklists

Author: (before you ask people to review this PR)

- [x] Diff - review it, ensuring it contains only expected changes
- [x] Whitespace changes - avoid if possible, because they make diffs harder to read and conflicts more likely
- [x] Changelog - add a line, if it meets the criteria
- [x] Secrets - no secrets should be added
- [x] Commit messages - say *why* the change was made
- [x] PR description - summarizes *what* changed and *why*, with a JIRA ticket ID
- [x] Tests pass - on CircleCI
- [x] Conflicts - resolve if Github reports them. e.g. with `git rebase main`

Reviewers remember:

- [ ] Jira ticket criteria are met
- [ ] Migrations - test migration and rollback: `rake db:migrate && rake db:rollback`
