### PR TITLE
re-enable undercover

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -216,9 +216,6 @@ jobs:
   unit_tests:
     executor: test-executor
     steps:
-      # Not using Circle's own `checkout` step, because of a subtle incompatibility with undercover
-      # it is effectively undocumented and unconfigurable, so its behaviour is unknown
-      # using it here makes the undercover step fail
       - run:
           environment:
             GIT_SSH_COMMAND: ssh -o StrictHostKeyChecking=accept-new

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -216,7 +216,7 @@ jobs:
   unit_tests:
     executor: test-executor
     steps:
-      # Circle's checkout step no longer works here
+      # Not using Circle's own `checkout` step, because of a subtle incompatibility with undercover
       # it is effectively undocumented and unconfigurable, so its behaviour is unknown
       # using it here makes the undercover step fail
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -216,7 +216,12 @@ jobs:
   unit_tests:
     executor: test-executor
     steps:
-      - checkout
+      - run:
+          environment:
+            GIT_SSH_COMMAND: ssh -o StrictHostKeyChecking=accept-new
+          name: Checkout code
+          command: |
+            git clone --progress -b "$CIRCLE_BRANCH" "$CIRCLE_REPOSITORY_URL" .
       - *install_packages_for_testing
       - *restore_gems_cache
       - *install_gems
@@ -225,14 +230,11 @@ jobs:
       - run:
           name: Run ruby tests
           command: |
-            bundle exec rspec --format progress --format RspecJunitFormatter -o /tmp/test-results/rspec/rspec.xml
-#      Disable undercover due to strange error only on circle
-#      /home/circleci/project/vendor/bundle/ruby/3.3.0/gems/undercover-0.5.0/lib/undercover/changeset.rb:27:in `each_patch':
-#  object not found - cannot read header for (edb67ef595741ed89a58df6a941a0272f2d4b218) (Rugged::OdbError)
-#      - run:
-#          name: Check coverage with undercover
-#          command: |
-#            bundle exec undercover -c origin/main -l coverage/lcov.info
+            bundle exec rake spec
+      - run:
+          name: Check coverage with undercover
+          command: |
+            bundle exec undercover -c origin/main -l coverage/lcov.info
       - store_test_results:
           path: /tmp/test-results/rspec
       - store_artifacts:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -216,12 +216,15 @@ jobs:
   unit_tests:
     executor: test-executor
     steps:
+      # Circle's checkout step no longer works here
+      # it is effectively undocumented and unconfigurable, so its behaviour is unknown
+      # using it here makes the undercover step fail
       - run:
           environment:
             GIT_SSH_COMMAND: ssh -o StrictHostKeyChecking=accept-new
           name: Checkout code
           command: |
-            git clone --progress -b "$CIRCLE_BRANCH" "$CIRCLE_REPOSITORY_URL" .
+            git clone -b "$CIRCLE_BRANCH" "$CIRCLE_REPOSITORY_URL" .
       - *install_packages_for_testing
       - *restore_gems_cache
       - *install_gems


### PR DESCRIPTION
No ticket

Re-enable undercover after 29th February issue

---

## Checklists

Author: (before you ask people to review this PR)

- [x] Diff - review it, ensuring it contains only expected changes
- [x] Whitespace changes - avoid if possible, because they make diffs harder to read and conflicts more likely
- [x] Changelog - add a line, if it meets the criteria
- [x] Secrets - no secrets should be added
- [x] Commit messages - say *why* the change was made
- [x] PR description - summarizes *what* changed and *why*, with a JIRA ticket ID
- [x] Tests pass - on CircleCI
- [x] Conflicts - resolve if Github reports them. e.g. with `git rebase main`

Reviewers remember:

- [ ] Jira ticket criteria are met
- [ ] Migrations - test migration and rollback: `rake db:migrate && rake db:rollback`
