### PR TITLE
fix deploy_main target to have build_and_push_staging_mtr

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -579,6 +579,12 @@ workflows:
           filters:
             branches:
               only: main
+      - build_and_push_staging_mtr:
+          context: cfe-civil-staging-mtr
+          filters:
+            branches:
+              only:
+                - main
       - end2end_tests:
           filters:
             branches:


### PR DESCRIPTION
No ticket

The 'deploy_main' target currently fails to deploy (something) as the duplicate build_and_push_staging_mtr step definition is missing 

---

## Checklists

Author: (before you ask people to review this PR)

- [x] Diff - review it, ensuring it contains only expected changes
- [x] Whitespace changes - avoid if possible, because they make diffs harder to read and conflicts more likely
- [x] Changelog - add a line, if it meets the criteria
- [x] Secrets - no secrets should be added
- [x] Commit messages - say *why* the change was made
- [x] PR description - summarizes *what* changed and *why*, with a JIRA ticket ID
- [x] Tests pass - on CircleCI
- [x] Conflicts - resolve if Github reports them. e.g. with `git rebase main`

Reviewers remember:

- [ ] Jira ticket criteria are met
- [ ] Migrations - test migration and rollback: `rake db:migrate && rake db:rollback`
