### PR TITLE
LEP-508 Docker images tagging - staging_mtr and production

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -278,7 +278,7 @@ jobs:
     executor: aws-ecr/default
     steps:
       - build_and_push:
-          docker_tag: dev
+          docker_tag: uat
 
   build_and_push_staging:
     executor: aws-ecr/default
@@ -291,14 +291,14 @@ jobs:
     executor: aws-ecr/default
     steps:
       - build_and_push:
-          docker_tag: latest
+          docker_tag: staging_mtr
       - notify_slack_on_failure
 
   build_and_push_production:
     executor: aws-ecr/default
     steps:
       - build_and_push:
-          docker_tag: latest
+          docker_tag: production
       - notify_slack_on_failure
 
   deploy_uat: &deploy_uat


### PR DESCRIPTION
<!--Ticket-->

https://dsdmoj.atlassian.net/browse/LEP-508

<!-- Describe *what* you did and *why* -->
staging_mtr and production need to have their own tags, so that they do not share an ECR lifecycle rule, otherwise lots of builds of one will cause the lifecycle rule to delete the in-use image for the other.

Also rename 'dev' to 'uat' so that we consistently tag by environment name. Will change the lifecycle rules to match.

---

## Checklists

Author: (before you ask people to review this PR)

- [ ] Diff - review it, ensuring it contains only expected changes
- [ ] Whitespace changes - avoid if possible, because they make diffs harder to read and conflicts more likely
- [ ] Changelog - add a line, if it meets the criteria
- [ ] Secrets - no secrets should be added
- [ ] Commit messages - say *why* the change was made
- [ ] PR description - summarizes *what* changed and *why*, with a JIRA ticket ID
- [ ] Tests pass - on CircleCI
- [ ] Conflicts - resolve if Github reports them. e.g. with `git rebase main`

Reviewers remember:

- [ ] Jira ticket criteria are met
- [ ] Migrations - test migration and rollback: `rake db:migrate && rake db:rollback`
