### PR TITLE
set use test data to false on production

### DIFF
--- a/deploy/helm/values/production.yaml
+++ b/deploy/helm/values/production.yaml
@@ -30,7 +30,7 @@ postgresql:
   enabled: false
 
 threshold:
-  useTestData: 'true'
+  useTestData: 'false'
 
 legalFrameworkApi:
   host: http://legal-framework-api.legal-framework-api-production.svc.cluster.local


### PR DESCRIPTION
No ticket

USE_TEST_THRESHOLD_DATA seems to be set true on production - don't think it should be

---

## Checklists

Author: (before you ask people to review this PR)

- [x] Diff - review it, ensuring it contains only expected changes
- [x] Whitespace changes - avoid if possible, because they make diffs harder to read and conflicts more likely
- [x] Changelog - add a line, if it meets the criteria
- [x] Secrets - no secrets should be added
- [x] Commit messages - say *why* the change was made
- [x] PR description - summarizes *what* changed and *why*, with a JIRA ticket ID
- [x] Tests pass - on CircleCI
- [x] Conflicts - resolve if Github reports them. e.g. with `git rebase main`

Reviewers remember:

- [ ] Jira ticket criteria are met
- [ ] Migrations - test migration and rollback: `rake db:migrate && rake db:rollback`
