### PR TITLE
LEP-501 part 2: turn off metabase in staging to manually test deploys

### DIFF
--- a/deploy/helm/values/staging.yaml
+++ b/deploy/helm/values/staging.yaml
@@ -43,5 +43,5 @@ notifications:
   recipient: stephen.p.dicks@digital.justice.gov.uk,ripan.kumar@digital.justice.gov.uk
 
 metabase:
-  enabled: true
+  enabled: false
   environment_name: staging


### PR DESCRIPTION
<!--Ticket-->

https://dsdmoj.atlassian.net/browse/LEP-501

There is an issue with metabase in staging. To try and fix this i am deploying manually to staging. However I am getting an error:

`ERROR: relation "core_user" already exists`

Which may be due to the existing metabase deployment in staging, deleting this pod manually is not possible so I want to remove it from staging until we can figure out the issue.


## Checklists

Author: (before you ask people to review this PR)

- [x] Diff - review it, ensuring it contains only expected changes
- [x] Whitespace changes - avoid if possible, because they make diffs harder to read and conflicts more likely
- [x] Changelog - add a line, if it meets the criteria
- [x] Secrets - no secrets should be added
- [x] Commit messages - say *why* the change was made
- [x] PR description - summarizes *what* changed and *why*, with a JIRA ticket ID
- [x] Tests pass - on CircleCI
- [x] Conflicts - resolve if Github reports them. e.g. with `git rebase main`

Reviewers remember:

- [ ] Jira ticket criteria are met
- [ ] Migrations - test migration and rollback: `rake db:migrate && rake db:rollback`
