### PR TITLE
LEP-508 ECR branch-name tags made unique

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -73,8 +73,8 @@ executors:
 commands:
   build_and_push:
     parameters:
-      docker_tag:
-        description: Destination docker_tag
+      docker_tag_prefix:
+        description: Docker repository tag prefix
         type: string
     steps:
       - checkout
@@ -89,7 +89,7 @@ commands:
       - aws-ecr/build_image:
           push_image: true
           account_id: $AWS_ECR_REGISTRY_ID
-          tag: ${CIRCLE_SHA1},<< parameters.docker_tag >>
+          tag: ${CIRCLE_SHA1},<< parameters.docker_tag_prefix >>-${CIRCLE_SHA1}  # add a suffix to make it unique, since a tag can point at only one image at a time
           region: $ECR_REGION # this will use the env var
           repo: $ECR_REPOSITORY # this will use the env var
 
@@ -280,27 +280,27 @@ jobs:
     executor: aws-ecr/default
     steps:
       - build_and_push:
-          docker_tag: uat
+          docker_tag_prefix: uat
 
   build_and_push_staging:
     executor: aws-ecr/default
     steps:
       - build_and_push:
-          docker_tag: staging
+          docker_tag_prefix: staging
       - notify_slack_on_failure
 
   build_and_push_staging_mtr:
     executor: aws-ecr/default
     steps:
       - build_and_push:
-          docker_tag: staging_mtr
+          docker_tag_prefix: staging_mtr
       - notify_slack_on_failure
 
   build_and_push_production:
     executor: aws-ecr/default
     steps:
       - build_and_push:
-          docker_tag: production
+          docker_tag_prefix: production
       - notify_slack_on_failure
 
   deploy_uat: &deploy_uat


### PR DESCRIPTION
Otherwise the tag is moved from previous images of the branch. So all the previous images of the branch are missed when the ECR image lifecycle_policy does its clean up.

https://dsdmoj.atlassian.net/browse/LEP-508

You can [view the ECR images](https://dsdmoj.atlassian.net/wiki/spaces/EPT/pages/4799397892/ECR+images) and this is what this branch's image looks like, including the revised tag:
`aws ecr describe-images --repository-name laa-eligibility-platform/cfe-civil-ecr |less`

<img width="751" alt="Screenshot 2024-03-29 at 12 27 24" src="https://github.com/ministryofjustice/cfe-civil/assets/307612/8e2e18e6-e640-4094-a2d6-fe36ff2955a5">

## Checklists

Author: (before you ask people to review this PR)

- [ ] Diff - review it, ensuring it contains only expected changes
- [ ] Whitespace changes - avoid if possible, because they make diffs harder to read and conflicts more likely
- [ ] Changelog - add a line, if it meets the criteria
- [ ] Secrets - no secrets should be added
- [ ] Commit messages - say *why* the change was made
- [ ] PR description - summarizes *what* changed and *why*, with a JIRA ticket ID
- [ ] Tests pass - on CircleCI
- [ ] Conflicts - resolve if Github reports them. e.g. with `git rebase main`

Reviewers remember:

- [ ] Jira ticket criteria are met
- [ ] Migrations - test migration and rollback: `rake db:migrate && rake db:rollback`
