### PR TITLE
Database Health Check

### DIFF
--- a/app/controllers/status_controller.rb
+++ b/app/controllers/status_controller.rb
@@ -24,6 +24,8 @@ private
   end
 
   def database_migrations_run?
-    ActiveRecord::Base.connection.table_exists?(RequestLog.table_name)
+    table = RequestLog.table_name
+    ActiveRecord::Base.connection.schema_cache.clear_data_source_cache!(table)
+    ActiveRecord::Base.connection.table_exists?(table)
   end
 end

--- a/app/controllers/status_controller.rb
+++ b/app/controllers/status_controller.rb
@@ -18,9 +18,12 @@ class StatusController < ApplicationController
 private
 
   def database_alive?
-    ActiveRecord::Base.connection.active?
-    RequestLog.first.present?
+    ActiveRecord::Base.connection.active? && database_migrations_run?
   rescue PG::ConnectionBad, PG::UndefinedTable
     false
+  end
+
+  def database_migrations_run?
+    ActiveRecord::Base.connection.table_exists?(RequestLog.table_name)
   end
 end


### PR DESCRIPTION
While looking at the healthcheck Steven and I noticed a potential bug. The two checks should probably be joined using && as opposed to being 2 different checks we also identified a ruby specific way to check a table exists so this replaces :
`RequestLog.first.present?` with `table_exists?`


---

## Checklists

Author: (before you ask people to review this PR)

- [x] Diff - review it, ensuring it contains only expected changes
- [x] Whitespace changes - avoid if possible, because they make diffs harder to read and conflicts more likely
- [x] Changelog - add a line, if it meets the criteria
- [x] Secrets - no secrets should be added
- [x] Commit messages - say *why* the change was made
- [x] PR description - summarizes *what* changed and *why*, with a JIRA ticket ID
- [x] Tests pass - on CircleCI
- [x] Conflicts - resolve if Github reports them. e.g. with `git rebase main`

Reviewers remember:

- [ ] Jira ticket criteria are met
- [ ] Migrations - test migration and rollback: `rake db:migrate && rake db:rollback`
