### PR TITLE
Update readme to clarify integration test setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,15 +141,15 @@ However for running the integration tests, you need a few more values, including
 
 It's recommended for devs to run 'Guard' in the background, to ensure RSwag rebuilds the swagger docs, and other tasks, before committing. This is more efficient than waiting for the CI to catch issues.
 
-    Run Guard through Bundler with
-    ```sh
-    bundle exec guard
-    ```
+Run Guard through Bundler with
+```sh
+bundle exec guard
+```
 
-    Show configuration options for each used plugin
-    ```sh
-    bundle exec guard show
-    ```
+Show configuration options for each used plugin
+```sh
+bundle exec guard show
+```
 
 ## Running the API locally
 
@@ -208,6 +208,14 @@ The file `values.yml` details the start dates for each set of thresholds, and th
 
 Whilst developing a thresholds .yml file, intended for a future date, you should include in it: `test_only: true`. This causes it *not* to be activated unless `FUTURE_THRESHOLD_FILE` is set to the same .yml filename. This is a protection against the thresholds file being used for actual assessments, in normal environments, where `FUTURE_THRESHOLD_FILE` is not set by default.
 
+For running locally, to activate the specified threshold file, as of today's date, and overriding the date specified in values.yml add the following to your .env file.
+
+```sh
+FUTURE_THRESHOLD_FILE=mtr-2026.yml
+```
+
+The thresholds file is activated even if it contains: `test_only: True`, as is likely.
+
 ## Tests
 
 CFE-Civil has several kinds of tests:
@@ -246,7 +254,6 @@ Environment variables:
 | GOOGLE_SHEETS_CLIENT_ID      | (secret)                                                                                |
 | RUNNING_AS_GITHUB_WORKFLOW   | `TRUE` / `FALSE`                                                                        |
 | LEGAL_FRAMEWORK_API_HOST     | `https://legal-framework-api-staging.apps.live-1.cloud-platform.service.justice.gov.uk` |
-| FUTURE_THRESHOLD_FILE        | `mtr-2026.yml` - activates the specified thresholds file, as of today's date, overriding the date specified in values.yml. The thresholds file is activated even if it contains: `test_only: True`, as is likely |
 
 #### Running RSpec tests
 


### PR DESCRIPTION
Remove FUTURE_THRESHOLD_FILE from .env setup, as this isn't required for the spreadsheet integration tests to pass, And will cause tests to fail when running bundle exec rspec or bundle exec cucumber.

This could be confusing for new developers.

Move the instructios for using the threshold file when running locally to the Test threshold data section instead.

<!--Ticket-->

https://dsdmoj.atlassian.net/browse/LEP-XXX

<!-- Describe *what* you did and *why* -->

---

## Checklists

Author: (before you ask people to review this PR)

- [ ] Diff - review it, ensuring it contains only expected changes
- [ ] Whitespace changes - avoid if possible, because they make diffs harder to read and conflicts more likely
- [ ] Changelog - add a line, if it meets the criteria
- [ ] Secrets - no secrets should be added
- [ ] Commit messages - say *why* the change was made
- [ ] PR description - summarizes *what* changed and *why*, with a JIRA ticket ID
- [ ] Tests pass - on CircleCI
- [ ] Conflicts - resolve if Github reports them. e.g. with `git rebase main`

Reviewers remember:

- [ ] Jira ticket criteria are met
- [ ] Migrations - test migration and rollback: `rake db:migrate && rake db:rollback`
