### PR TITLE
EL-2127: add new thresholds configuration file.

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,7 +206,7 @@ The file `values.yml` details the start dates for each set of thresholds, and th
 
 ### Test threshold data
 
-Whilst developing a thresholds .yml file, intended for a future date, you should include in it: `test_only: true`. This causes it *not* to be activated unless `FUTURE_THRESHOLD_FILE` is set to the same .yml filename. This is a protection against the thresholds file being used for actual assessments, in normal environments, where `FUTURE_THRESHOLD_FILE` is not set by default.
+Whilst developing a thresholds .yml file, intended for a future date, you should include in it: `test_only: true`. This causes it *not* to be activated. This is a protection against the thresholds file being used for actual assessments, in production environments.
 
 For running locally, to activate the specified threshold file, as of today's date, and overriding the date specified in values.yml add the following to your .env file.
 
@@ -214,7 +214,11 @@ For running locally, to activate the specified threshold file, as of today's dat
 FUTURE_THRESHOLD_FILE=mtr-2026.yml
 ```
 
-The thresholds file is activated even if it contains: `test_only: True`, as is likely.
+Similarly, a new threshold file can similarly be activated for testing purposes in UAT (as of today's date, and overriding the date specified in values.yml) by adding something like the following to uat.yaml
+
+```sh
+futureFile: '2025-04-07.yml'
+```
 
 ## Tests
 

--- a/config/thresholds/2025-04-07.yml
+++ b/config/thresholds/2025-04-07.yml
@@ -1,0 +1,79 @@
+---
+# test_only: true
+
+gross_income_upper: 2657
+infinite_gross_income_upper: 999_999_999_999
+gross_income:
+  dependant_step: 222
+  dependant_increase_starts_after: 4
+disposable_income_lower_certificated: 315
+disposable_income_lower_controlled: 733
+disposable_income_upper: 733
+disposable_income_certificated_immigration_asylum_upper_tribunal: 733
+capital_lower_certificated: 3_000
+capital_upper: 8_000
+capital_immigration_first_tier_tribunal_controlled: 3_000
+capital_immigration_upper_tribunal_certificated: 3_000
+capital_asylum_upper_tribunal_certificated: 8_000
+partner_allowance: 228.56
+pensioner_capital_disregard:
+  minimum_age_in_years: 60
+  passported: 100_000
+  non_passported: 100_000
+  # capital to disregard if monthly disposable income (excluding income derived from capital) is below these figures
+  monthly_income_values:
+    [-.inf, 25.00]: 100_000
+    [25.01, 50.00]: 90_000
+    [50.01, 75.00]: 80_000
+    [75.01, 100.00]: 70_000
+    [100.01, 125.00]: 60_000
+    [125.01, 150.00]: 50_000
+    [150.01, 175.00]: 40_000
+    [175.01, 200.00]: 30_000
+    [200.01, 225.00]: 20_000
+    [225.01, 315.00]: 10_000
+    [315.01, .inf]: 0
+property_notional_sale_costs_percentage: 3.0
+property_maximum_mortgage_allowance: 999_999_999_999
+property_disregard:
+  main_home: 100_000.0
+  additional_property: 0.0
+vehicle_disregard: 15_000
+vehicle_out_of_scope_months: 36
+
+dependant_allowances:
+  child_under_15: 367.87
+  child_aged_15: 367.87
+  child_16_and_over: 367.87
+  adult: 367.87
+  adult_capital_threshold: 8_000
+
+single_monthly_housing_costs_cap: 545
+
+disposable_income_contribution_bands:
+  bands:
+    band_zero:
+      threshold: -.inf
+      disregard: 0.0
+      percentage: 0.0
+      base: 0.0
+    band_a:
+      threshold: 315.0
+      disregard: 311.0
+      percentage: 35.0
+      base: 0
+    band_b:
+      threshold: 466
+      disregard: 465
+      percentage: 45.0
+      base: 53.90
+    band_c:
+      threshold: 617
+      disregard: 616
+      percentage: 70.0
+      base: 121.85
+  minimum_contribution: 0.0
+
+fixed_employment_allowance: 45.0
+employment_income_variance: 60.0
+subject_matter_of_dispute_disregard: 100000.0

--- a/config/thresholds/values.yml
+++ b/config/thresholds/values.yml
@@ -7,6 +7,7 @@
 2022-04-11: config/thresholds/2022-04-11.yml
 2023-04-10: config/thresholds/2023-04-10.yml
 2024-04-08: config/thresholds/2024-04-08.yml
+2025-04-07: config/thresholds/2025-04-07.yml
 # MTR is under development, so marked 'test_only'.
 # MTR implementation date is just a placeholder for now.
 2026-04-01: config/thresholds/mtr-2026.yml

--- a/features/dependant/dependant_income.feature
+++ b/features/dependant/dependant_income.feature
@@ -41,3 +41,15 @@ Feature:
       | dependant allowance under 16      | 0.0     |
       | dependant allowance over 16       | 0.0     |
 
+  Scenario: Dependant has non-zero weekly income that exceeds allowance threshold after 7/4/2025
+    Given I am undertaking a certificated assessment
+    And A submission date of "2025-04-07"
+    And I have a dependant aged 2
+    And I have a dependant aged 17
+
+    When I retrieve the final assessment
+    Then I should see the following overall summary:
+      | attribute                         | value   |
+      | dependant allowance under 16      | 367.87  |
+      | dependant allowance over 16       | 367.87  |
+

--- a/features/partner/partner_assessment.feature
+++ b/features/partner/partner_assessment.feature
@@ -116,3 +116,17 @@ Scenario: An applicant and partner's combined capital is over the lower threshol
       | assessment_result              | eligible |
       | partner allowance              | 211.32   |
       | dependant allowance            | 338.9    |
+
+  Scenario: A partner case on or after 7th April 2025
+    Given I am undertaking a certificated assessment
+    And A submission date of "2025-04-07"
+    And I have a dependant aged 2
+    And I add the following capital details for "bank_accounts" for the partner:
+      | description  | value   |
+      | Bank account | 2000.0  |
+    When I retrieve the final assessment
+    Then I should see the following overall summary:
+      | attribute                      | value    |
+      | assessment_result              | eligible |
+      | partner allowance              | 228.56   |
+      | dependant allowance            | 367.87   |

--- a/spec/models/threshold_spec.rb
+++ b/spec/models/threshold_spec.rb
@@ -83,6 +83,27 @@ RSpec.describe Threshold do
     end
   end
 
+  context "7th April 2025" do
+    let(:time) { Time.zone.parse("07-Apr-2025") }
+    let(:expected_dependant_allowances) do
+      {
+        child_under_15: 367.87,
+        child_aged_15: 367.87,
+        child_16_and_over: 367.87,
+        adult: 367.87,
+        adult_capital_threshold: 8_000,
+      }
+    end
+
+    it "picks up the values from the 2025-04-07 file" do
+      expect(described_class.value_for(:dependant_allowances, at: time)).to eq expected_dependant_allowances
+    end
+
+    it "has a new partner allowance" do
+      expect(described_class.value_for(:partner_allowance, at: time)).to eq(228.56)
+    end
+  end
+
   context "MTR" do
     context "when setting future test file" do
       before { allow(Rails.configuration.x).to receive(:future_test_data_file).and_return(override_filename) }


### PR DESCRIPTION
Add new thresholds configuration file with uprated partner and dependant allowances

<!--Ticket-->

https://dsdmoj.atlassian.net/browse/LEP-2127

Can be tested using using swagger and the request details I have added to the ticket.

The threshold value file changes are not loaded if test_only: true is added, I have commented this out to allow for testing, but we should probably add it before merging (however, we would then need to remove it again before the 7/4). That is why I have added the do not merge label.

Adding futureFile: '2025-04-07.yml' overrides the effective date and sets it to today's date again to allow for testing. If necessary for testing purposes I think we can set this to be a different date in values.yml.

I think our readme is slightly confusing around threshold value file testing and could probably do with updating.

---

## Checklists

Author: (before you ask people to review this PR)

- [ ] Diff - review it, ensuring it contains only expected changes
- [ ] Whitespace changes - avoid if possible, because they make diffs harder to read and conflicts more likely
- [ ] Changelog - add a line, if it meets the criteria
- [ ] Secrets - no secrets should be added
- [ ] Commit messages - say *why* the change was made
- [ ] PR description - summarizes *what* changed and *why*, with a JIRA ticket ID
- [ ] Tests pass - on CircleCI
- [ ] Conflicts - resolve if Github reports them. e.g. with `git rebase main`

Reviewers remember:

- [ ] Jira ticket criteria are met
- [ ] Migrations - test migration and rollback: `rake db:migrate && rake db:rollback`
