### PR TITLE
AP-5044: Remove the full_s8_only from LFA

### DIFF
--- a/spec/cassettes/LegalFrameworkAPI_ThresholdWaivers/_call/successful_API_call/responds_to_calling_service_with_parsed_response.yml
+++ b/spec/cassettes/LegalFrameworkAPI_ThresholdWaivers/_call/successful_API_call/responds_to_calling_service_with_parsed_response.yml
@@ -2,13 +2,13 @@
 http_interactions:
 - request:
     method: post
-    uri: https://legal-framework-api-staging.cloud-platform.service.justice.gov.uk/threshold_waivers
+    uri: https://ap-5044-remove-full-s8-legal-framework-uat.cloud-platform.service.justice.gov.uk/threshold_waivers
     body:
       encoding: UTF-8
       string: '{"request_id":"e76bd31f-dd62-444f-9d7d-a731b40b7eea","proceedings":[{"ccms_code":"DA001","client_involvement_type":"A"},{"ccms_code":"DA002","client_involvement_type":"D"},{"ccms_code":"DA003","client_involvement_type":"W"},{"ccms_code":"DA004","client_involvement_type":"I"},{"ccms_code":"DA005","client_involvement_type":"Z"},{"ccms_code":"SE014","client_involvement_type":"A"}]}'
     headers:
       User-Agent:
-      - Faraday v1.10.3
+      - Faraday v2.13.1
       Content-Type:
       - application/json
       Accept-Encoding:
@@ -21,11 +21,11 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 07 Dec 2023 09:16:43 GMT
+      - Fri, 13 Jun 2025 07:07:43 GMT
       Content-Type:
       - application/json; charset=utf-8
       Content-Length:
-      - '1197'
+      - '1321'
       Connection:
       - keep-alive
       X-Frame-Options:
@@ -41,23 +41,23 @@ http_interactions:
       Vary:
       - Accept, Origin
       Etag:
-      - W/"bac93e7297adcaeba0aefbcec39c267a"
+      - W/"af80f223ab798b7955ea60ae0bc6a7d2"
       Cache-Control:
       - max-age=0, private, must-revalidate
       X-Request-Id:
-      - deb1175374e6c1a7d51b655bd5d380a1
+      - 21e54e62286747b8cc58ed26b9ce322b
       X-Runtime:
-      - '0.033459'
+      - '0.023387'
       Strict-Transport-Security:
-      - max-age=15724800; includeSubDomains
+      - max-age=31536000; includeSubDomains
     body:
       encoding: UTF-8
-      string: '{"request_id":"e76bd31f-dd62-444f-9d7d-a731b40b7eea","success":true,"proceedings":[{"ccms_code":"DA001","full_s8_only":false,"matter_type":"Domestic
-        abuse","gross_income_upper":true,"disposable_income_upper":true,"capital_upper":true,"client_involvement_type":"A"},{"ccms_code":"DA002","full_s8_only":false,"matter_type":"Domestic
-        abuse","gross_income_upper":false,"disposable_income_upper":false,"capital_upper":false,"client_involvement_type":"D"},{"ccms_code":"DA003","full_s8_only":false,"matter_type":"Domestic
-        abuse","gross_income_upper":false,"disposable_income_upper":false,"capital_upper":false,"client_involvement_type":"W"},{"ccms_code":"DA004","full_s8_only":false,"matter_type":"Domestic
-        abuse","gross_income_upper":false,"disposable_income_upper":false,"capital_upper":false,"client_involvement_type":"I"},{"ccms_code":"DA005","full_s8_only":false,"matter_type":"Domestic
-        abuse","gross_income_upper":false,"disposable_income_upper":false,"capital_upper":false,"client_involvement_type":"Z"},{"ccms_code":"SE014","full_s8_only":false,"matter_type":"Children
-        - section 8","gross_income_upper":false,"disposable_income_upper":false,"capital_upper":false,"client_involvement_type":"A"}]}'
-  recorded_at: Thu, 07 Dec 2023 09:16:43 GMT
-recorded_with: VCR 6.2.0
+      string: '{"request_id":"e76bd31f-dd62-444f-9d7d-a731b40b7eea","success":true,"proceedings":[{"ccms_code":"DA001","sca_core":false,"sca_related":false,"matter_type":"domestic
+        abuse (DA)","gross_income_upper":true,"disposable_income_upper":true,"capital_upper":true,"client_involvement_type":"A"},{"ccms_code":"DA002","sca_core":false,"sca_related":false,"matter_type":"domestic
+        abuse (DA)","gross_income_upper":false,"disposable_income_upper":false,"capital_upper":false,"client_involvement_type":"D"},{"ccms_code":"DA003","sca_core":false,"sca_related":false,"matter_type":"domestic
+        abuse (DA)","gross_income_upper":false,"disposable_income_upper":false,"capital_upper":false,"client_involvement_type":"W"},{"ccms_code":"DA004","sca_core":false,"sca_related":false,"matter_type":"domestic
+        abuse (DA)","gross_income_upper":false,"disposable_income_upper":false,"capital_upper":false,"client_involvement_type":"I"},{"ccms_code":"DA005","sca_core":false,"sca_related":false,"matter_type":"domestic
+        abuse (DA)","gross_income_upper":false,"disposable_income_upper":false,"capital_upper":false,"client_involvement_type":"Z"},{"ccms_code":"SE014","sca_core":false,"sca_related":false,"matter_type":"section
+        8 children (S8)","gross_income_upper":false,"disposable_income_upper":false,"capital_upper":false,"client_involvement_type":"A"}]}'
+  recorded_at: Fri, 13 Jun 2025 07:07:43 GMT
+recorded_with: VCR 6.3.1

--- a/spec/cassettes/V6_AssessmentsController/POST_/create/non_means_tested/certificated/when_applicant_over_18/is_not_eligible.yml
+++ b/spec/cassettes/V6_AssessmentsController/POST_/create/non_means_tested/certificated/when_applicant_over_18/is_not_eligible.yml
@@ -2,13 +2,13 @@
 http_interactions:
 - request:
     method: post
-    uri: https://legal-framework-api-staging.cloud-platform.service.justice.gov.uk/threshold_waivers
+    uri: https://ap-5044-remove-full-s8-legal-framework-uat.cloud-platform.service.justice.gov.uk/threshold_waivers
     body:
       encoding: UTF-8
-      string: '{"request_id":"10a128c5-4715-4c5a-ada7-83b9191953bf","proceedings":[{"ccms_code":"SE003","client_involvement_type":"I"}]}'
+      string: '{"request_id":"f6399052-8f78-4b83-9751-b686f571fe05","proceedings":[{"ccms_code":"DA005","client_involvement_type":"Z"}]}'
     headers:
       User-Agent:
-      - Faraday v1.10.3
+      - Faraday v2.13.1
       Content-Type:
       - application/json
       Accept-Encoding:
@@ -21,11 +21,11 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 08 Dec 2023 12:37:30 GMT
+      - Fri, 13 Jun 2025 07:07:09 GMT
       Content-Type:
       - application/json; charset=utf-8
       Content-Length:
-      - '275'
+      - '290'
       Connection:
       - keep-alive
       X-Frame-Options:
@@ -41,18 +41,18 @@ http_interactions:
       Vary:
       - Accept, Origin
       Etag:
-      - W/"fd98c5ee3dab7b0047996c2e714b4ee8"
+      - W/"7b5a958981b4780da1b4cd59c607479a"
       Cache-Control:
       - max-age=0, private, must-revalidate
       X-Request-Id:
-      - a1f80ab203b8c581b8f128d83e123dfe
+      - 7dac75909952682aa931efb20aa134ff
       X-Runtime:
-      - '0.058834'
+      - '0.011763'
       Strict-Transport-Security:
-      - max-age=15724800; includeSubDomains
+      - max-age=31536000; includeSubDomains
     body:
       encoding: UTF-8
-      string: '{"request_id":"10a128c5-4715-4c5a-ada7-83b9191953bf","success":true,"proceedings":[{"ccms_code":"SE003","full_s8_only":false,"matter_type":"Children
-        - section 8","gross_income_upper":false,"disposable_income_upper":false,"capital_upper":false,"client_involvement_type":"I"}]}'
-  recorded_at: Fri, 08 Dec 2023 12:37:30 GMT
-recorded_with: VCR 6.2.0
+      string: '{"request_id":"f6399052-8f78-4b83-9751-b686f571fe05","success":true,"proceedings":[{"ccms_code":"DA005","sca_core":false,"sca_related":false,"matter_type":"domestic
+        abuse (DA)","gross_income_upper":false,"disposable_income_upper":false,"capital_upper":false,"client_involvement_type":"Z"}]}'
+  recorded_at: Fri, 13 Jun 2025 07:07:09 GMT
+recorded_with: VCR 6.3.1

--- a/spec/services/legal_framework_api/threshold_waivers_spec.rb
+++ b/spec/services/legal_framework_api/threshold_waivers_spec.rb
@@ -28,8 +28,9 @@ RSpec.describe LegalFrameworkAPI::ThresholdWaivers do
       %i[DA002 DA003 DA004 DA005].map do |code|
         {
           ccms_code: code.to_s,
-          full_s8_only: false,
-          matter_type: "Domestic abuse",
+          sca_core: false,
+          sca_related: false,
+          matter_type: "domestic abuse (DA)",
           gross_income_upper: false,
           disposable_income_upper: false,
           capital_upper: false,
@@ -44,8 +45,9 @@ RSpec.describe LegalFrameworkAPI::ThresholdWaivers do
         proceedings: [
           {
             ccms_code: "DA001",
-            full_s8_only: false,
-            matter_type: "Domestic abuse",
+            sca_core: false,
+            sca_related: false,
+            matter_type: "domestic abuse (DA)",
             gross_income_upper: true,
             disposable_income_upper: true,
             capital_upper: true,
@@ -54,12 +56,13 @@ RSpec.describe LegalFrameworkAPI::ThresholdWaivers do
         ] + non_waived_types + [
           {
             ccms_code: "SE014",
-            full_s8_only: false,
+            sca_core: false,
+            sca_related: false,
             client_involvement_type: "A",
             gross_income_upper: false,
             disposable_income_upper: false,
             capital_upper: false,
-            matter_type: "Children - section 8",
+            matter_type: "section 8 children (S8)",
           },
         ],
       }


### PR DESCRIPTION
`full_s8_only` is an obsolete value, it was implemented so we could release the section Section 8 matter type in two phases and the need was removed many years, and matter types, ago.

It has been removed from LFA so this PR is to reduce any unnecessary complexity in the CFE code base

https://dsdmoj.atlassian.net/browse/AP-5044

While re-recording the cassettes it updated some other changed values

---

## Checklists

Author: (before you ask people to review this PR)

- [x] Diff - review it, ensuring it contains only expected changes
- [x] Whitespace changes - avoid if possible, because they make diffs harder to read and conflicts more likely
- [ ] Changelog - add a line, if it meets the criteria
- [x] Secrets - no secrets should be added
- [x] Commit messages - say *why* the change was made
- [x] PR description - summarizes *what* changed and *why*, with a JIRA ticket ID
- [ ] Tests pass - on CircleCI
- [x] Conflicts - resolve if Github reports them. e.g. with `git rebase main`

Reviewers remember:

- [ ] Jira ticket criteria are met
- [ ] Migrations - test migration and rollback: `rake db:migrate && rake db:rollback`
