### PR TITLE
CHORE: group bundler dependabots

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,9 +8,14 @@ updates:
       day: "monday"
       time: "09:00"
     groups:
+      rubocop:
+        patterns:
+          - "rubocop*"
       bundler:
         patterns:
           - "*"
+        exclude-patterns:
+          - "rubocop*"
 
   - package-ecosystem: "github-actions"
     directory: "/"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,6 +7,10 @@ updates:
       # Our UAT databases are down at night - so run things at 9am on Mondays instead
       day: "monday"
       time: "09:00"
+    groups:
+      bundler:
+        patterns:
+          - "*"
 
   - package-ecosystem: "github-actions"
     directory: "/"


### PR DESCRIPTION

Group bundler dependabot prs to make reviewing/merging quicker.

I don't think we see many docker or github-actions dependabots, so I don't think it is worth grouping these currently.

## Checklists

Author: (before you ask people to review this PR)

- [ ] Diff - review it, ensuring it contains only expected changes
- [ ] Whitespace changes - avoid if possible, because they make diffs harder to read and conflicts more likely
- [ ] Changelog - add a line, if it meets the criteria
- [ ] Secrets - no secrets should be added
- [ ] Commit messages - say *why* the change was made
- [ ] PR description - summarizes *what* changed and *why*, with a JIRA ticket ID
- [ ] Tests pass - on CircleCI
- [ ] Conflicts - resolve if Github reports them. e.g. with `git rebase main`

Reviewers remember:

- [ ] Jira ticket criteria are met
- [ ] Migrations - test migration and rollback: `rake db:migrate && rake db:rollback`
