### PR TITLE
AP-6214: Amend postgresql chart to use bitnami legacy image repository

### DIFF
--- a/bin/uat_deploy
+++ b/bin/uat_deploy
@@ -8,10 +8,13 @@ deploy() {
 
   echo "Deploying CIRCLE_SHA1: $CIRCLE_SHA1 under release name: '$RELEASE_NAME'..."
 
+  # Temporary solution:  amend postgres chart's to use bitnamilegacy for its image repository. See https://github.com/bitnami/charts/issues/35164 for details
   helm upgrade $RELEASE_NAME ./deploy/helm/. \
                 --install --wait \
                 --namespace=${K8S_NAMESPACE} \
                 --values ./deploy/helm/values/uat.yaml \
+                --set postgresql.image.repository=bitnamilegacy/postgresql \
+                --set postgresql.global.security.allowInsecureImages=true \
                 --set deploy.host="$RELEASE_HOST" \
                 --set image.repository="$IMG_REPO" \
                 --set image.tag="$CIRCLE_SHA1" \


### PR DESCRIPTION
## What 
Amend postgresql chart to use bitnami legacy image repository

https://dsdmoj.atlassian.net/browse/AP-6214

Following the deprecation of support for such images by bitnami.

see [bitnami chart issue](https://github.com/bitnami/charts/issues/35164)

## Before
```sh
Containers:
  postgresql:
    Container ID:   containerd://redacted
    Image:          docker.io/bitnami/postgresql:14.5.0-debian-11-r35
    Image ID:       docker.io/bitnami/postgresql@sha256:<redacted>
```

## After
```sh
Containers:
  postgresql:
    Container ID:   containerd://redacted
    Image:          docker.io/bitnamilegacy/postgresql:14.5.0-debian-11-r35
    Image ID:       docker.io/bitnamilegacy/postgresql@sha256:<redacted>
```
## Checklists

Author: (before you ask people to review this PR)

- [ ] Diff - review it, ensuring it contains only expected changes
- [ ] Whitespace changes - avoid if possible, because they make diffs harder to read and conflicts more likely
- [ ] Changelog - add a line, if it meets the criteria
- [ ] Secrets - no secrets should be added
- [ ] Commit messages - say *why* the change was made
- [ ] PR description - summarizes *what* changed and *why*, with a JIRA ticket ID
- [ ] Tests pass - on CircleCI
- [ ] Conflicts - resolve if Github reports them. e.g. with `git rebase main`

Reviewers remember:

- [ ] Jira ticket criteria are met
- [ ] Migrations - test migration and rollback: `rake db:migrate && rake db:rollback`
