### PR TITLE
ap-6218: use new external secret

### DIFF
--- a/README.md
+++ b/README.md
@@ -330,17 +330,6 @@ This app is deployed on Cloud Platform by CircleCI, using the Helm chart in depl
 
 [CircleCI pipeline for cfe-civil](https://app.circleci.com/pipelines/github/ministryofjustice/cfe-civil)
 
-## Kubernetes secrets
-
-Secrets are sourced from 1Password and deployed into an environment/namespace by manually running `kubectl create secret` commands. See: https://dsdmoj.atlassian.net/wiki/spaces/EPT/pages/4356833911/Secrets
-
-Within the `kube-secrets` k8s secret, the following keys are available:
-
-* notifications-api-key
-* sentry-dsn
-* secret-key-base
-* postgresql-postgres-password (for UAT only, as this environment has a pod running Postgres instead of an RDS instance)
-
 ## port-forward-pod
 
 For the Production & Staging namespaces there is a "port-forward-pod" deployment, which forwards localhost:5432 to rds-host:5432. This allows the developer to connect to the database in the namespace, as if they were running locally, on their machine.

--- a/deploy/helm/templates/_envs.tpl
+++ b/deploy/helm/templates/_envs.tpl
@@ -38,13 +38,13 @@ env:
   - name: SECRET_KEY_BASE
     valueFrom:
       secretKeyRef:
-        name: kube-secrets
-        key: secret-key-base
+        name: cfe-civil-secrets
+        key: secretKeyBase
   - name: SENTRY_DSN
     valueFrom:
       secretKeyRef:
-        name: kube-secrets
-        key: sentry-dsn
+        name: cfe-civil-secrets
+        key: sentryDsn
   - name: RAILS_ENV
     value: production
   - name: RUBY_YJIT_ENABLE
@@ -62,8 +62,8 @@ env:
   - name: NOTIFICATIONS_API_KEY
     valueFrom:
       secretKeyRef:
-        name: kube-secrets
-        key: notifications-api-key
+        name: cfe-civil-secrets
+        key: notificationsApiKey
   - name: NOTIFICATIONS_ERROR_MESSAGE_TEMPLATE_ID
     value: {{ .Values.notifications.errorMessageTemplateId }}
   - name: NOTIFICATIONS_RECIPIENT


### PR DESCRIPTION
Also, update readme.

## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-6218)

Use new external secret; cfe-civil-secrets.
Update readme.

TODO

Once this pr is merged the kubernetes secret kube-secrets can be removed.

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`.
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- The standards in the [Git Workflow document on Confluence](https://dsdmoj.atlassian.net/wiki/spaces/ATPPB/pages/4602855954/Git+Workflow) should be followed.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
