### PR TITLE
CHORE Update the circleci postgres version that tests run against

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -37,7 +37,7 @@ executors:
           - PGUSER=user
           - TZ: "Europe/London"
           - RUBY_YJIT_ENABLE: "1"
-      - image: cimg/postgres:14.8
+      - image: cimg/postgres:17.5
         environment:
           - POSTGRES_USER=user
           - POSTGRES_DB=cfe_civil_test
@@ -52,7 +52,7 @@ executors:
           PGUSER: postgres
           TZ: "Europe/London"
           CFE_HOST: http://localhost:3000
-      - image: cimg/postgres:14.8
+      - image: cimg/postgres:17.4
         environment:
           POSTGRES_USER: postgres
           POSTGRES_DB: ccq_test


### PR DESCRIPTION
## What

Update the postgres version that tests run against.

I have made this 17.5 for CFE test (as there is currently no cimg/postgres:17.6) and 17.4 for the CCQ integration tests (as this is the version of postgres that CCQ uses).

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`.
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- The standards in the [Git Workflow document on Confluence](https://dsdmoj.atlassian.net/wiki/spaces/ATPPB/pages/4602855954/Git+Workflow) should be followed.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
