### PR TITLE
CHORE update readme to remove details of port forward pod

### DIFF
--- a/README.md
+++ b/README.md
@@ -329,11 +329,3 @@ d) new value (only for change and addition)
 This app is deployed on Cloud Platform by CircleCI, using the Helm chart in deploy/helm.
 
 [CircleCI pipeline for cfe-civil](https://app.circleci.com/pipelines/github/ministryofjustice/cfe-civil)
-
-## port-forward-pod
-
-For the Production & Staging namespaces there is a "port-forward-pod" deployment, which forwards localhost:5432 to rds-host:5432. This allows the developer to connect to the database in the namespace, as if they were running locally, on their machine.
-
-For deployment files and for further information, please see:
-- `infrastructure/cfe-civil-production/deployment_port-forward-postgres.yaml`
-- `infrastructure/cfe-civil-staging/deployment_port-forward-postgres.yaml`


### PR DESCRIPTION
## What

CHORE: update readme to remove details of port forward pod.

This was deleted in this pr https://github.com/ministryofjustice/cfe-civil/pull/850

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`.
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- The standards in the [Git Workflow document on Confluence](https://dsdmoj.atlassian.net/wiki/spaces/ATPPB/pages/4602855954/Git+Workflow) should be followed.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
