### PR TITLE
Fix: correct brakeman sha pinning

### DIFF
--- a/.github/workflows/brakeman-analysis.yml
+++ b/.github/workflows/brakeman-analysis.yml
@@ -11,4 +11,4 @@ jobs:
   brakeman:
     permissions:
       security-events: write # for github/codeql-action/upload-sarif to upload SARIF results
-    uses: ministryofjustice/laa-reusable-github-actions/.github/workflows/brakeman.yml@0a0bd8225ca8cc96e57a19223ce21f2ce7230833c # main as of 24/06/2026
+    uses: ministryofjustice/laa-reusable-github-actions/.github/workflows/brakeman.yml@df9a4a8ad625a391c27ccf81a1c1a2d7b23e6474 # main as of 24/06/2026


### PR DESCRIPTION
## What
Correct brakeman sha pinning.

Replace with latest sha anyway, but previous sha had an extra `0` at the beginning  due to some typo.

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`.
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- The standards in the [Git Workflow document on Confluence](https://dsdmoj.atlassian.net/wiki/spaces/ATPPB/pages/4602855954/Git+Workflow) should be followed.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
